### PR TITLE
fix isNaN bug

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -11,7 +11,7 @@ return function(column){
 	column.renderCell = function(object, value, td, options){
 		// summary:
 		//		Renders a cell that can be expanded, creating more rows
-		var level = options.query.level + 1;
+		var level = Number(options.query.level) + 1;
 		level = isNaN(level) ? 0 : level;
 		var grid = this.grid;
 		var mayHaveChildren = !grid.store.mayHaveChildren || grid.store.mayHaveChildren(object);


### PR DESCRIPTION
explicitly cast before adding -- if options.query.level is a string coercion will bite and the isNaN check won't help you if it's also a valid number, a classic jswtf: e.g. `s = "3"; s += 1; // "31"; isNaN(s) // false`
