### PR TITLE
Style improvements for column sets with uneven column heights.

### DIFF
--- a/ColumnSet.js
+++ b/ColumnSet.js
@@ -13,7 +13,9 @@ function(styleSheet, has, put, declare, listen, aspect, query, Grid, hasClass){
 			for(var i = 0, l = this.columnSets.length; i < l; i++){
 				// iterate through the columnSets
 				var columnSet = this.columnSets[i];
-				var cell = put(tr, tag + ".dgrid-column-set-cell.column-set-" + i + " div.dgrid-column-set[colsetid=" + i + "]");
+				
+				var cell = put(tr, tag + ".dgrid-column-set-cell.column-set-" + i + (tag == "td" ? "[height=100%]" : "") + " div.dgrid-column-set[colsetid=" + i + "]");
+				
 				this.subRows = columnSet;
 				cell.appendChild(this.inherited(arguments));
 			}

--- a/css/columnset.css
+++ b/css/columnset.css
@@ -2,11 +2,13 @@
 	overflow: hidden;
 	width: 100%;
 	position: relative; /* This is needed because we setting position: relative on cells in the grid for focus in IE7*/
+	height: 100% !important; /* Fixes Firefox + WebKit border issues */
 }
 
 .dgrid-column-set-cell {
 	vertical-align: top;
 }
+
 .dgrid-column-set-scroller {
 	position: absolute;
 	bottom: 0px;


### PR DESCRIPTION
Style improvements for column sets with uneven column heights.  Improves WebKit and Firefox;  IE and Opera still display borders improperly.  The general thought is that this styling is not a huge issue
