### PR TITLE
Ensure sort details included in the sortOptions are retained in the grid.sortOrder array property

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -40,6 +40,10 @@ return declare([List], {
 		//		and tells it to refresh.
 		this.query = query !== undefined ? query : this.query;
 		this.queryOptions = queryOptions || this.queryOptions;
+		// stash sort details if the queryOptions included them
+		if(queryOptions && queryOptions.sort){
+			this.sortOrder = queryOptions.sort;
+		}
 		this.refresh();
 	},
 	

--- a/test/test_OnDemand.html
+++ b/test/test_OnDemand.html
@@ -182,6 +182,36 @@
 						console.log("reset query to show all");
 						grid.setQuery({});
 					});
+					
+					var sortDescending = true;
+					
+					on(document.getElementById("setQueryWithOptions"), "click", function(){
+						// set sortOrder for the col1 field
+						sortDescending ^= 1; // toggle true/false
+					
+						// get an existing sortOrder
+						var sortByCol1 = dojo.filter(
+								grid.sortOrder || [], 
+								function(sortBy){
+									return sortBy.attribute == "col1";
+								}
+						).shift();
+						if(sortByCol1){
+							console.log("modifying existing sortOrder for col1: ", sortByCol1);
+						} else {
+							sortByCol1 = { attribute: "col1" };
+						}
+						sortByCol1.descending = sortDescending;
+						grid.setQuery(grid.query, { sort: [sortByCol1] });
+					});
+					on(document.getElementById("sort"), "click", function(){
+						console.log("sortOrder: ", grid.sortOrder);
+						
+						sortDescending ^= 1; // toggle true/false
+						grid.sort("col1", sortDescending);
+					});
+
+
 					on(document.getElementById("empty"), "click", function(){
 						console.log("set store to emptyStore");
 						grid.setStore(emptyStore, {});
@@ -252,6 +282,8 @@
 		<button id="restore">Set Original Store</button>
 		<button id="colorQuery">Set color store and query</button>
 		<button id="resetQuery">Reset query</button>
+		<button id="setQueryWithOptions">Set query with queryOptions</button>
+		<button id="sort">sort</button>
 		<button id="empty">Set to empty store</button>
 		<button id="error">Set to error store</button>
 		<button id="error2">Set to error store (def)</button>


### PR DESCRIPTION
This is re: https://github.com/SitePen/dgrid/issues/20

I'm not 100% sure if this is /the/ issue, but it is /an/ issue: if a call to setQuery is made with a queryOptions pbag that includes a sort property, that should replace the existing sortOrder on the grid/list. That way, when renderQuery calls the query callback, the sortOrder array is up to date. 

This pull request includes the change in OnDemandList and the test_onDemand.html page. 
