### PR TITLE
Changing cell border strategy from using border-tops to border-bottoms

### DIFF
--- a/List.js
+++ b/List.js
@@ -345,9 +345,11 @@ function(put, declare, listen, aspect, has, TouchScroll, hasClass){
 			}
 			function whenDone(resolvedRows){
 				(beforeNode && beforeNode.parentNode || self.contentNode).insertBefore(rowsFragment, beforeNode || null);
+				/*
 				if(!beforeNode){
 					put(lastRow, ".dgrid-last-row");
 				}
+				*/
 				return rows = resolvedRows;
 			}
 			return whenDone(rows);

--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -108,9 +108,11 @@ return declare([List], {
 				if(trCount){ self.rowHeight = height / trCount; }
 				
 				total -= trCount;
+				/*
 				if(!total && trCount && rootQuery){
 					put(trs[trCount-1], ".dgrid-last-row");
 				}
+				*/
 				preloadNode.count = total;
 				preloadNode.start = trCount;
 				if(total){


### PR DESCRIPTION
Changing cell border strategy from using border-tops to border-bottoms, so we don't need to keep track of the last row
