### PR TITLE
columnresizer bug fix

### DIFF
--- a/extensions/ColumnResizer.js
+++ b/extensions/ColumnResizer.js
@@ -23,7 +23,7 @@ return declare([], {
 
 		for(id in this.columns){
 			var col = this.columns[id];
-			var colNode = query("#" + grid.domNode.id + " .column-"+id)[0];//grabs header node
+			var colNode = query(".column-"+id, grid.domNode)[0]; //grabs header node
 
 			var headerTextNode = put("div.dgrid-resize-header-container");
 			colNode.contents = headerTextNode;


### PR DESCRIPTION
scope query to grid node, works regardless of whether grid is attached to document
