### PR TITLE
Adding cursor:pointer to '+' for usability purposes

### DIFF
--- a/css/extensions/ColumnHider.css
+++ b/css/extensions/ColumnHider.css
@@ -1,5 +1,6 @@
 .dgrid-hider-toggle {
 	font-weight:normal;
+	cursor: pointer;
 }
 .dgrid-hider-toggle:hover {
 	font-weight: bold;


### PR DESCRIPTION
The "+" should have a pointer cursor so people know they can click on it.
