### PR TITLE
grid_header_resize fix

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -355,7 +355,6 @@ define(["dojo/has", "put-selector/put", "dojo/_base/declare", "dojo/on", "./Edit
 		_updateColumns: function(){
 			// summary:
 			//		Called after e.g. columns, subRows, columnSets are updated
-			
 			this.configStructure();
 			this.renderHeader();
 			this.refresh();

--- a/List.js
+++ b/List.js
@@ -189,7 +189,9 @@ function(put, declare, listen, aspect, has, TouchScroll, hasClass){
 			this.renderHeader();
 			
 			this.contentNode = put(this.bodyNode, "div.dgrid-content.ui-widget-content");
-			this._listeners.push(listen(window, "resize",
+			//added a handle to the window resize handler, so we can kill it if the grid is
+			//inside of a dijit layout
+			this._listeners.push(this.resizeHandle = listen(window, "resize",
 				has("ie") < 7 && !has("quirks") ? function(evt){
 					// IE6 triggers window.resize on any element resize;
 					// avoid useless calls (and infinite loop if height: auto).
@@ -216,7 +218,7 @@ function(put, declare, listen, aspect, has, TouchScroll, hasClass){
 			// summary:
 			//		Called automatically after postCreate if the component is already
 			//		visible; otherwise, should be called manually once placed.
-			
+
 			this.inherited(arguments);
 			if(this._started){ return; } // prevent double-triggering
 			this._started = true;
@@ -422,7 +424,7 @@ function(put, declare, listen, aspect, has, TouchScroll, hasClass){
 		},
 		_autoId: 0,
 		renderHeader: function(){
-			// no-op in a place list 
+			// no-op in a place list
 		},
 		insertRow: function(object, parent, beforeNode, i, options){
 			// summary:

--- a/extensions/DijitRegistry.js
+++ b/extensions/DijitRegistry.js
@@ -11,13 +11,18 @@ function(declare, registry){
 		
 		buildRendering: function(){
 			registry.add(this);
-			
 			this.inherited(arguments);
-			
 			// Note: for dojo 2.0 may rename widgetId to dojo._scopeName + "_widgetId"
 			this.domNode.setAttribute("widgetId", this.id);
 		},
-		
+		startup: function(){
+			this.inherited(arguments);
+			var parent = registry.getEnclosingWidget(this.domNode.parentNode);
+			//if parent is a widget - remove the window resize listener that List sets on the grid
+			if(parent){
+				this.resizeHandle.remove();
+			}
+		},
 		destroy: function(){
 			this.inherited(arguments);
 			registry.remove(this);

--- a/test/dijit_layout.html
+++ b/test/dijit_layout.html
@@ -31,6 +31,7 @@
 			function showDeclDialog(){ dlgDecl.show(); }
 			
 			require(["dgrid/OnDemandGrid",
+				"dgrid/extensions/DijitRegistry",
 				"dijit/Dialog",
 				"dojo/_base/lang",
 				"dojo/_base/declare",
@@ -44,7 +45,7 @@
 				// non-returns
 				"dgrid/test/data/base",
 				"dojo/domReady!"
-			], function(Grid, Dialog, lang, declare, parser){
+			], function(Grid, DijitRegistry, Dialog, lang, declare, parser){
 			
 				var
 					gridCols = window.gridCols = {
@@ -52,10 +53,10 @@
 						col2: {name: 'Column 2', sortable: false},
 						col3: 'Column 3',
 						col4: 'Column 4'
-					}
-
+					},
+				CustomGrid = declare([Grid, DijitRegistry]);
 				// simply passing columns via data-dojo-props, don't want GridFromHtml
-				window.dgrid = { Grid: Grid };
+				window.dgrid = { Grid: CustomGrid };
 				
 				parser.parse();
 			});
@@ -98,9 +99,9 @@
 						data-dojo-props="store: testStore, columns: gridCols"></div>
 				</div>
 				<!-- tab 3: dgrid directly as tab child
-					Doesn't seem to work (tab doesn't appear) -->
+					Doesn't seem to work (tab doesn't appear and breaks DijitRegistry)
 				<div data-dojo-type="dgrid.Grid" id="gridTab3" class="gridTab"
-					data-dojo-props="store: testStore, columns: gridCols, title: 'Tab 3'"></div>
+					data-dojo-props="store: testStore, columns: gridCols, title: 'Tab 3'"></div>-->
 			</div>
 		</div>
 		<!-- declarative dialog w/ dgrid inside -->

--- a/test/dijit_layout_programmatic.html
+++ b/test/dijit_layout_programmatic.html
@@ -124,6 +124,5 @@
 	</head>
 	<body class="claro">
 		<div id="bc"></div>
-		<div id="gridTab1"></div>
 	</body>
 </html>


### PR DESCRIPTION
Fixes to both List and DijitRegistry to support a dgrid being used inside of a layout dijit.  This fix adds DijitRegistry to the dijit_layout test to resolve both the dialog grid header being missing on show, and the headers disappearing upon window resize. 
