### PR TITLE
OnDemandList stops scrolling after refresh() is called

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -122,6 +122,9 @@ return declare([List, _StoreMixin], {
 	
 	refresh: function(){
 		this.inherited(arguments);
+		// clear any preload data as it might contain DOM elements that were
+		// removed from the DOM in the parent method (List#refresh)
+		this.preload = null;
 		if(this.store){
 			// render the query
 			var self = this;


### PR DESCRIPTION
Scroll paging stopped working for me after the switch to preload objects and after some debugging I found out that while refresh() causes the whole grid to be redrawn the preload objects can still contain DOM elements (the preload nodes) which were removed from the DOM. 
This in turn causes viewport visibility calculations to fail because the detached nodes always report their offsetTop to be zero. 

This patch clears the preload object when refresh() is called, eliminating the problem.
I'm not 100% sure this is the proper way to deal with it but it does work and I can't think of any other issues it might raise. 
