### PR TITLE
Fix DijitRegistry issues

### DIFF
--- a/extensions/DijitRegistry.js
+++ b/extensions/DijitRegistry.js
@@ -26,10 +26,14 @@ function(declare, registry){
 				this._resizeHandle.remove();
 			}
 		},
+
+		destroyRecursive: function() {
+			this.destroy();
+		},
 		
 		destroy: function(){
 			this.inherited(arguments);
-			registry.remove(this);
+			registry.remove(this.id);
 		},
 		
 		getChildren: function(){


### PR DESCRIPTION
After using the DijitRegistry extension I noticed that it was not actually removing the widget from the registry. Also I was getting "Tried to register widget with id==..." errors if I loaded the same page twice and this was due to ContentPanes checking for and calling destroyRecursive on its child widgets. Destroy never actually was called.

Use widget id as argument for registry.remove as it takes an id and not a widget instance.
Add destroyRecursive method because containers check for and call destroyRecursive in their destroyDecendants cleanup.
