### PR TITLE
AutoScrollbar extension + dgrid-autoheight class

### DIFF
--- a/css/dgrid.css
+++ b/css/dgrid.css
@@ -195,3 +195,22 @@ html.has-mozilla .dgrid-focus {
 #dgrid-css-dgrid-loaded {
 	display: none;
 }
+
+/* styles for autoheight */
+.dgrid-autoheight {
+    height: auto;
+}
+.dgrid-autoheight .dgrid-scroller {
+    position: relative;
+    overflow-y: hidden;
+}
+.has-ie-6 .dgrid-autoheight .dgrid-scroller {
+    /* IE6 doesn't react properly to hidden for some reason */
+    overflow-y: visible;
+}
+.dgrid-autoheight .dgrid-header-scroll {
+    display: none;
+}
+.dgrid-autoheight .dgrid-header {
+    right: 0;
+}

--- a/extensions/AutoScrollbar.js
+++ b/extensions/AutoScrollbar.js
@@ -1,0 +1,81 @@
+define(["dojo/_base/declare", "dojo/_base/lang", "dojo/_base/Deferred", "dojo/has", "dojo/aspect", "put-selector/put", 
+	"../util/misc"], 
+function(declare, lang, Deferred, has, aspect, put, misc){
+	return declare(null, {
+		// summary:
+		//    When used within a Dijit layout widget, automatically displays and hides the vertical scrollbar as needed.
+		//    It is recommended that lists/grids that use this extension also use the DijitRegistry plugin.
+		
+		/** The last size we were asked to be by our container */
+		_lastSize: null, 
+		
+		postscript: function(){
+			var self = this,
+				// We may get many row additions/removals in a short period of time
+				throttledCheckScrollbars = misc.throttleCombined(function(){ 
+					self._checkScrollbars();
+					if(has("ie") == 6){ setTimeout(function(){ self.resize(); }); }
+				});
+			
+			// Normally we need to check the scrollbars *before* the normal resize code happens, but on startup we 
+			// need the resize code to set the grid up for us so we can work out the preferred size. Thus we set up
+			// a one-off notification, and from there install the rest of our listeners
+			var afterResize = aspect.after(this, "resize", function(currentSize){
+				afterResize.remove();
+				throttledCheckScrollbars();
+				
+				aspect.after(this, "resize", misc.throttleCombined(this._checkScrollbars, this, null, true), true);
+				aspect.after(this, "renderArray", function(rows){
+					// Only check the scrollbars after the rows have been rendered
+					Deferred.when(rows, throttledCheckScrollbars);
+					return rows;
+				});
+				aspect.after(this, "newRow", throttledCheckScrollbars, true);
+				aspect.after(this, "removeRow", throttledCheckScrollbars, true);
+			}, true);
+			
+			this.inherited(arguments);
+		},
+		
+		_checkScrollbars: function(currentSize){
+			if(!currentSize){
+				// If we've come in from an entry point other than resize(), we will not be given currentSize
+				currentSize = this._lastSize;	
+			}
+			// Give up if we don't know what size we're supposed to be; if we're within a layout widget eventually we
+			// should get a call with currentSize defined
+			if(currentSize){
+				var 
+					contentNode = this.contentNode, 
+					contentNodeHeight = contentNode.style.height,
+					bodyNode = this.bodyNode,
+					bodyNodeHeight = bodyNode.style.height,
+					scrollTop = bodyNode.scrollTop;
+	
+				// "Free" its height so we can measure its natural size
+				contentNode.style.height = "auto";
+				
+				// Add/remove the vertical scrollbar as needed
+				if(currentSize.h < this.headerNode.offsetHeight + contentNode.offsetHeight + this.footerNode.offsetHeight){
+					put(this.domNode, "!dgrid-autoheight");
+					this.domNode.style.height = Math.max(1, currentSize.h) + "px";
+				}else{
+					put(this.domNode, ".dgrid-autoheight");
+					this.domNode.style.height = "";
+				}
+				
+				// Remember this so that calls from renderArray()/newRow()/removeRow() know the last requested size
+				this._lastSize = currentSize;
+				
+				// We changed this in order to measure the correct height	
+				contentNode.style.height = contentNodeHeight;
+				// Restore the scrollbar position to stop it jumping to the top
+				this.bodyNode.scrollTop = scrollTop;
+				
+				if(has("ie") == 6 && bodyNodeHeight.indexOf("px") != -1 && bodyNodeHeight != bodyNode.clientHeight + "px"){
+					this.resize();
+				}
+			}
+		}
+	});
+});

--- a/test/autoheight.html
+++ b/test/autoheight.html
@@ -17,24 +17,6 @@
 				width: 400px;
 			}
 			
-			/* styles for autoheight */
-			#grid {
-				height: auto;
-			}
-			#grid .dgrid-scroller {
-				position: relative;
-				overflow-y: hidden;
-			}
-			.has-ie-6 #grid .dgrid-scroller {
-				/* IE6 doesn't react properly to hidden on this page for some reason */
-				overflow-y: visible;
-			}
-			#grid .dgrid-header-scroll {
-				display: none;
-			}
-			#grid .dgrid-header {
-				right: 0;
-			}
 		</style>
 		<script type="text/javascript" src="../../dojo/dojo.js" 
 			data-dojo-config="async: true"></script>
@@ -55,7 +37,7 @@
 	</head>
 	<body class="claro">
 		<h2>A basic grid with height:auto</h2>
-		<div id="grid"></div>
+		<div id="grid" class="dgrid-autoheight"></div>
 		<a href="https://github.com/SitePen/dgrid">dgrid</a>
 	</body>
 </html>

--- a/test/extensions/AutoScrollbar.html
+++ b/test/extensions/AutoScrollbar.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Test AutoScrollbar</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+		<meta name="viewport" content="width=570"/>
+		<style type="text/css">
+			@import "../../../dijit/themes/claro/document.css";
+			@import "../../../dijit/themes/claro/claro.css";
+			@import "../../css/skins/claro.css";
+			html, body {
+				padding: 0;
+				margin: 0;
+				width: 100%;
+				height: 100%;
+			}
+			#bc {
+				height: 100%;
+			}
+			
+			#cpLeft .dgrid {
+				width: 300px;
+			}
+			
+			.dijitDialog {
+				width: 500px;
+			}
+		</style>
+		<script type="text/javascript" src="../../../dojo/dojo.js"
+			data-dojo-config="async: true"></script>
+		<script type="text/javascript">
+			require(["dgrid/OnDemandGrid",
+				"dgrid/Selection",
+				"dgrid/extensions/DijitRegistry",
+				"dgrid/extensions/AutoScrollbar",
+				"dojo/_base/lang",
+				"dojo/_base/declare",
+				"dojo/store/Memory", 
+				"dojo/store/Observable",
+				"dijit/layout/BorderContainer",
+				"dijit/layout/ContentPane",
+				"dijit/form/Button",
+				// non-returns
+				"dgrid/test/data/base",
+				"dojo/domReady!"
+			], function(OnDemandGrid, Selection, DijitRegistry, AutoScrollbar, lang, declare, Memory, Observable, BC, CP, Button){
+				
+				var
+					allColors = smallColorStore.query(),
+					nextColorId = allColors[allColors.length - 1].id + 1,
+					localColorStore = Observable(new Memory({data: allColors.concat()})),
+					asyncCols = {
+						col1: "Column 1", 
+						col2: "Column 2", 
+						col3: "Column 3", 
+						col4: 'Column 4'},
+					colorCols = {
+						col1: "Color name", 
+						col3: "Type", 
+						col4: {formatter: function(value) { return value; }, label: 'Description'}, 
+						col5: "Red", 
+						col6: "Green", 
+						col7: "Blue"},
+					CustomGrid = declare([OnDemandGrid, Selection, DijitRegistry, AutoScrollbar]),
+					gridLeft = new CustomGrid({
+						id: "gridLeft",
+						store: testAsyncStore,
+						columns: lang.clone(asyncCols),
+						selectionMode: "single"
+					}),
+					gridTop = new CustomGrid({
+						id: "gridTop",
+						store: localColorStore,
+						columns: lang.clone(colorCols),
+						selectionMode: "single"
+					}), 
+				   buttonsDiv = document.createElement("div"),
+					addRowButton = new Button({label: "Add row"}),
+					removeRowButton = new Button({label: "Remove row"}),
+					toggleRowButton = new Button({label: "Toggle first row height"}),
+					bc = new BC({
+						design: "sidebar"
+					}, "bc");
+				
+				var leftCp = new CP({
+					content: gridLeft,
+					region: "left", 
+					splitter: true
+				});
+				leftCp.domNode.style.width = "400px";
+				bc.addChild(leftCp);
+				bc.addChild(new CP({
+					content: gridTop,
+					region: "center"
+				}));
+				
+				addRowButton.on("click", function() { 
+					localColorStore.add(
+							  lang.mixin({}, allColors[Math.floor(Math.random() * allColors.length)], {id: nextColorId++}));
+				});
+				removeRowButton.on("click", function() {
+					localColorStore.remove((localColorStore.query().pop() || {}).id);
+				});
+				toggleRowButton.on("click", function() {
+					var firstRow = lang.mixin({}, localColorStore.query()[0]);
+					if (firstRow) {
+						if (firstRow.col4.indexOf("<br/>") == -1) {
+							firstRow.col4 = "=======<br/>" + firstRow.col4 + "<br/>======="; 
+						} else {
+							firstRow.col4 = firstRow.col4.split("<br/>")[1];
+						}
+						
+						localColorStore.put(firstRow);
+					}
+				});
+				
+				buttonsDiv.appendChild(addRowButton.domNode);
+				buttonsDiv.appendChild(removeRowButton.domNode);
+				buttonsDiv.appendChild(toggleRowButton.domNode);
+				
+				bc.addChild(new CP({
+					content: buttonsDiv,
+					region: "bottom",
+					splitter: true
+				}));
+				bc.startup();
+			});
+		</script>
+	</head>
+	<body class="claro">
+		<div id="bc"></div>
+	</body>
+</html>

--- a/util/misc.js
+++ b/util/misc.js
@@ -1,6 +1,5 @@
 define([], function(){
 	// This module defines miscellaneous utility methods.
-	
 	var util = {
 		defaultDelay: 15,
 		throttle: function(cb, context, delay){
@@ -16,20 +15,48 @@ define([], function(){
 				setTimeout(function(){ ran = false; }, delay);
 			}
 		},
-		throttleDelayed: function(cb, context, delay){
+		throttleDelayed: function(cb, context, delay, useLastArgs){
 			// summary:
 			//		Like throttle, except that the callback runs after the delay,
 			//		rather than before it.
-			var ran = false;
+			//		useLastArgs: If true, the arguments from the last invocation will be used, matching debounce()
+			var ran = false,
+				a;
 			delay = delay || util.defaultDelay;
 			return function(){
+				if(!ran || useLastArgs){
+					a = arguments;
+				}
 				if(ran){ return; }
 				ran = true;
-				var a = arguments;
 				setTimeout(function(){
 					cb.apply(context, a);
 					ran = false;
 				}, delay);
+			}
+		},
+		throttleCombined: function(cb, context, delay, useLastArgs){
+			// summary:
+			//		A combination of throttle and throttleDelayed; The first call within delay passes through immediately
+			//		so the action appears instantaneous to the user, but any further calls within delay are collapsed into 
+			//		a single call. Note that this call will fire twice per delay if continuously invoked. 
+			//		useLastArgs: If true, the arguments from the last invocation will be used, matching debounce() 
+			var count = 0, 
+				a;
+			delay = delay || util.defaultDelay;
+			return function(){
+				if(!count++ || useLastArgs){
+					a = arguments;
+				}
+				if(count == 1){
+					cb.apply(context, a);
+					setTimeout(function(){
+						if(count > 1){
+							cb.apply(context, a);
+						}
+						count = 0;
+					}, delay);
+				}
 			}
 		},
 		debounce: function(cb, context, delay){


### PR DESCRIPTION
Moved autoheight-related CSS rules into dgrid-autoheight class
Created AutoScrollbar extension that will automatically display/hide the vertical scrollbar as needed when the grid is within a layout widget
