### PR TITLE
Reverse order of setting ran to false so that the throttled function can...

### DIFF
--- a/util/misc.js
+++ b/util/misc.js
@@ -27,8 +27,8 @@ define([], function(){
 				ran = true;
 				var a = arguments;
 				setTimeout(function(){
-					cb.apply(context, a);
 					ran = false;
+					cb.apply(context, a);
 				}, delay);
 			}
 		},


### PR DESCRIPTION
... call its own throttler and ensure that it will run itself again eventually. This fixes paging when the minRowsPerPage/maxRowsPerPage is less than the size of the visible area, allowing the processScroll to keep calling itself until it has covered the visible area.
