### PR TITLE
Fixes to isSelected

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -281,14 +281,14 @@ return declare([List], {
 		}
 	},
 	isSelected: function(object){
-		if(!object){
+		if(object===undefined || object===null){
 			return false;
 		}
 		if(!object.element){
 			object = this.row(object);
 		}
 
-		return !!this.selection[object.id];
+		return (object.id in this.selection)? !!this.selection[object.id] : this.allSelected;
 	},
 	
 	refresh: function(){


### PR DESCRIPTION
Fixed two problems I noticed with Selection.isSelected():
- deal more correctly with falsy ids (like 0)
- allow it to return the correct value when selectAll has been issued, but the user has not scrolled through all the data in an onDemand list.  Previously, it would only return true for isSelected() if the key was in the selection object, but in an onDemand list the key doesn't end up in the selection object until the row's page was scrolled into view.  As a result, if you did a selectAll(), then there were a lot of objects that should be considered to be selected that isSelected() was returning false for.  Basically, I just copied the logic used elsewhere to determine selection into isSelected(), so that if "selectAll" is true and the key is not in the selection object, then it should return true instead of false.
