### PR TITLE
Adjustments for ARIA compliance

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -119,6 +119,7 @@ function(kernel, declare, listen, has, put, List){
 							(id ? ".dgrid-column-" + id : "") +
 							(extraClassName ? "." + extraClassName : "")
 						).replace(invalidClassChars,"-"));
+					cell.setAttribute("role", "gridcell");
 					cell.columnId = id;
 					if(contentBoxSizing){
 						// The browser (IE7-) does not support box-sizing: border-box, so we emulate it with a padding div
@@ -170,7 +171,7 @@ function(kernel, declare, listen, has, put, List){
 			// row gets a wrapper div for a couple reasons:
 			//	1. So that one can set a fixed height on rows (heights can't be set on <table>'s AFAICT)
 			// 2. So that outline style can be set on a row when it is focused, and Safari's outline style is broken on <table>
-			return put("div[role=gridcell]>", row);
+			return put("div[role=row]>", row);
 		},
 		renderHeader: function(){
 			// summary:
@@ -211,8 +212,8 @@ function(kernel, declare, listen, has, put, List){
 			headerNode.appendChild(row);
 			// if it columns are sortable, resort on clicks
 			listen(row, "click,keydown", function(event){
-				// respond to click or space keypress
-				if(event.type == "click" || event.keyCode == 32){
+				// respond to click, space keypress, or enter keypress
+				if(event.type == "click" || event.keyCode == 32 /* space bar */ || event.keyCode == 13 /* enter */){
 					var
 						target = event.target,
 						field, descending, parentNode, sort;

--- a/Keyboard.js
+++ b/Keyboard.js
@@ -25,7 +25,7 @@ has.add("dom-contains", function(){
 function contains(parent, node){
 	// summary:
 	//		Checks to see if an element is contained by another element.
-	
+
 	if(has("dom-contains")){
 		return parent.contains(node);
 	}else{
@@ -38,28 +38,28 @@ return declare([List], {
 	// 		Add keyboard navigation capability to a grid/list
 	pageSkip: 10,
 	tabIndex: 0,
-	
+
 	postCreate: function(){
 		this.inherited(arguments);
 		var grid = this;
-		
+
 		function handledEvent(event){
 			// text boxes and other inputs that can use direction keys should be ignored and not affect cell/row navigation
 			var target = event.target;
 			return target.type && (!delegatingInputTypes[target.type] || event.keyCode == 32);
 		}
-		
+
 		function navigateArea(areaNode){
 			var isFocusableClass = grid.cellNavigation ? hasGridCellClass : hasGridRowClass,
 				cellFocusedElement = areaNode,
 				next;
-			
+
 			function focusOnCell(element, event, dontFocus){
 				var cell = grid[grid.cellNavigation ? "cell" : "row"](element);
-				
+
 				element = cell && cell.element;
 				if(!element){ return; }
-				
+
 				if(!event.bubbles){
 					// IE doesn't always have a bubbles property already true, Opera will throw an error if you try to set it to true if it is already true
 					event.bubbles = true;
@@ -91,10 +91,11 @@ return declare([List], {
 				on.emit(cellFocusedElement, "dgrid-cellfocusin", lang.mixin({ parentType: event.type }, event));
 			}
 
-			while((next = cellFocusedElement.firstChild) && next.tagName){
+			while((next = cellFocusedElement.firstChild) && !isFocusableClass.test(next.className)){
 				cellFocusedElement = next;
 			}
-			
+			if(next){ cellFocusedElement = next; }
+
 			if(areaNode === grid.contentNode){
 				aspect.after(grid, "renderArray", function(ret){
 					// summary:
@@ -125,20 +126,20 @@ return declare([List], {
 			}else if(isFocusableClass.test(cellFocusedElement.className)){
 				cellFocusedElement.tabIndex = grid.tabIndex;
 			}
-			
+
 			on(areaNode, "mousedown", function(event){
 				if(!handledEvent(event)){
 					focusOnCell(event.target, event);
 				}
 			});
-			
+
 			on(areaNode, "keydown", function(event){
 				// For now, don't squash browser-specific functionalities by letting
 				// ALT and META function as they would natively
 				if(event.metaKey || event.altKey) {
 					return;
 				}
-				
+
 				var focusedElement = event.target;
 				var keyCode = event.keyCode;
 				if(handledEvent(event)){
@@ -201,17 +202,17 @@ return declare([List], {
 				}
 				event.preventDefault();
 			});
-			
+
 			return function(target){
 				target = target || cellFocusedElement;
 				focusOnCell(target, { target: target });
 			}
 		}
-		
+
 		if(this.tabableHeader){
 			this.focusHeader = navigateArea(this.headerNode);
 		}
-		
+
 		this.focus = navigateArea(this.contentNode);
 	}
 });


### PR DESCRIPTION
- The Enter key is now a valid activator for sorting columns
- The Enter key is now a valid activator for selector-based checkboxes
- Each dgrid row now has a role of "row" instead of "gridcell"
- Each dgrid cell now has a role of "gridcell" instead of no role

Also, looks like my editor got a little aggressive with cleaning whitespace at end-of-line.
