### PR TITLE
Editor tweaks

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -281,7 +281,6 @@ function showEditor(cmp, column, cellElement, value){
 		// Set value, but ensure it isn't processed as a user-generated change.
 		// (Clear flag on a timeout to wait for delayed onChange to fire first)
 		cmp._dgridIgnoreChange = true;
-		cmp.set("value", value);
         // Call optional column property 'onEdit'. Both the row data object
         // and the widget are passed. Useful if widget needs to change itself
         // depending on particular cell's data.
@@ -289,6 +288,7 @@ function showEditor(cmp, column, cellElement, value){
             var obj = column.grid.cell(cellElement).row.data;
             column.onEdit(obj, cmp);
         }
+		cmp.set("value", value);
 		setTimeout(function(){ cmp._dgridIgnoreChange = false; }, 0);
 	}
 	// track previous value for short-circuiting or in case we need to revert


### PR DESCRIPTION
A couple of small tweaks to editor.js:
- Always-on editors weren't calling canEdit
- Columns can have an optional onEdit function which is called before showing the editor widget. I need this in my code because I have a custom widget that changes itself depending on which cell is being edited.
