### PR TITLE
Make event handling more consistent, with uniform access to "grid", "cel...

### DIFF
--- a/Keyboard.js
+++ b/Keyboard.js
@@ -55,11 +55,15 @@ return declare([List], {
 				next;
 			
 			function focusOnCell(element, event, dontFocus){
-				var cell = grid[grid.cellNavigation ? "cell" : "row"](element);
+				var cellOrRowType = grid.cellNavigation ? "cell" : "row";
+				var cell = grid[cellOrRowType](element);
 				
 				element = cell && cell.element;
 				if(!element){ return; }
-				
+				event = lang.mixin({
+					parentType: event.type,
+					grid: grid
+				}, event);
 				if(!event.bubbles){
 					// IE doesn't always have a bubbles property already true, Opera will throw an error if you try to set it to true if it is already true
 					event.bubbles = true;
@@ -72,11 +76,13 @@ return declare([List], {
 						// clean up after workaround below (for non-input cases)
 						cellFocusedElement.style.position = "";
 					}
-					event.cell = cellFocusedElement;
+					event.cell = cellFocusedElement; // keeping this for some level of back-compat for when we passed in an element
+					event[cellOrRowType] = grid[cellOrRowType](cellFocusedElement); // set the cell or row
 					on.emit(element, "dgrid-cellfocusout", event);
 				}
 				cellFocusedElement = element;
-				event.cell = element;
+				event.cell = element; // keeping this for some level of back-compat for when we passed in an element
+				event[cellOrRowType] = cell;
 				if(!dontFocus){
 					if(has("ie") < 8){
 						// setting the position to relative magically makes the outline
@@ -88,7 +94,7 @@ return declare([List], {
 					element.focus();
 				}
 				put(element, ".dgrid-focus");
-				on.emit(cellFocusedElement, "dgrid-cellfocusin", lang.mixin({ parentType: event.type }, event));
+				on.emit(cellFocusedElement, "dgrid-cellfocusin", event);
 			}
 
 			while((next = cellFocusedElement.firstChild) && next.tagName){

--- a/editor.js
+++ b/editor.js
@@ -46,7 +46,7 @@ function dataFromEditor(column, cmp){
 	}
 }
 
-function setProperty(grid, cellElement, oldValue, value){
+function setProperty(grid, cellElement, oldValue, value, triggerEvent){
 	// Updates dirty hash and fires dgrid-datachange event for a changed value.
 	var cell, row, column;
 	// test whether old and new values are inequal, with coercion (e.g. for Dates)
@@ -64,7 +64,8 @@ function setProperty(grid, cellElement, oldValue, value){
 						oldValue: oldValue,
 						value: value,
 						bubbles: true,
-						cancelable: true
+						cancelable: true,
+						parentType: triggerEvent && triggerEvent.type
 					})){
 				if(grid.updateDirty){
 					// for OnDemandGrid: update dirty data, and save if autoSave is true
@@ -83,12 +84,12 @@ function setProperty(grid, cellElement, oldValue, value){
 }
 
 // intermediary frontend to setProperty for HTML and widget editors
-function setPropertyFromEditor(grid, column, cmp) {
+function setPropertyFromEditor(grid, column, cmp, triggerEvent) {
 	var value;
 	if(!cmp.isValid || cmp.isValid()){
 		value = setProperty(grid, (cmp.domNode || cmp).parentNode,
 			activeCell ? activeValue : cmp._dgridLastValue,
-			dataFromEditor(column, cmp));
+			dataFromEditor(column, cmp), triggerEvent);
 		
 		if(activeCell){ // for editors with editOn defined
 			activeValue = value;
@@ -123,14 +124,14 @@ function createEditor(column){
 		// the latter is delayed by setTimeouts in Dijit and will fire too late.
 		cmp.connect(cmp, editOn ? "onBlur" : "onChange", function(){
 			if(!cmp._dgridIgnoreChange){
-				setPropertyFromEditor(grid, column, this);
+				setPropertyFromEditor(grid, column, this, {type: "widget"});
 			}
 		});
 	}else{
 		handleChange = function(evt){
 			var target = evt.target;
 			if("_dgridLastValue" in target && target.className.indexOf("dgrid-input") > -1){
-				setPropertyFromEditor(grid, column, target);
+				setPropertyFromEditor(grid, column, target, evt);
 			}
 		};
 

--- a/selector.js
+++ b/selector.js
@@ -53,29 +53,33 @@ function(kernel, arrayUtil, on, aspect, has, put){
 			// the shiftKey property from
 			if(event.type == "click" || event.keyCode == 32 || event.keyCode == 0){ 
 				var row = grid.row(event), lastRow = grid._lastSelected && grid.row(grid._lastSelected);
-	
-				if(type == "radio"){
-					if(!lastRow || lastRow.id != row.id){
-						grid.clearSelection();
-						grid.select(row, null, true);
-						grid._lastSelected = row.element;
-					}
-				}else{
-					if(row){
-						if(event.shiftKey){
-							// make sure the last input always ends up checked for shift key 
-							changeInput(true)({rows: [row]});
-						}else{
-							// no shift key, so no range selection
-							lastRow = null;
+				grid._triggerEvent = event;
+				try{
+					if(type == "radio"){
+						if(!lastRow || lastRow.id != row.id){
+							grid.clearSelection();
+							grid.select(row, null, true);
+							grid._lastSelected = row.element;
 						}
-						lastRow = event.shiftKey ? lastRow : null;
-						grid.select(lastRow|| row, row, lastRow ? undefined : null);
-						grid._lastSelected = row.element;
 					}else{
-						put(this, (grid.allSelected ? "!" : ".") + "dgrid-select-all");
-						grid[grid.allSelected ? "clearSelection" : "selectAll"]();
+						if(row){
+							if(event.shiftKey){
+								// make sure the last input always ends up checked for shift key 
+								changeInput(true)({rows: [row]});
+							}else{
+								// no shift key, so no range selection
+								lastRow = null;
+							}
+							lastRow = event.shiftKey ? lastRow : null;
+							grid.select(lastRow|| row, row, lastRow ? undefined : null);
+							grid._lastSelected = row.element;
+						}else{
+							put(this, (grid.allSelected ? "!" : ".") + "dgrid-select-all");
+							grid[grid.allSelected ? "clearSelection" : "selectAll"]();
+						}
 					}
+				}finally{
+					grid._triggerEvent = null;
 				}
 			}
 		}


### PR DESCRIPTION
...l" or "row" as a Cell or Row object, and "parentType" as an indicator of the event trigger type, equal to null or undefined if programmatically triggered.
