### PR TITLE
Calculate widths before actively setting sizes

### DIFF
--- a/extensions/ColumnResizer.js
+++ b/extensions/ColumnResizer.js
@@ -225,8 +225,17 @@ return declare([], {
 				});
 			}
 
-			colNodes.forEach(function(colNode){
-				this.resizeColumnWidth(colNode.columnId, colNode.offsetWidth);
+			// Get a set of sizes before we start mutating, to avoid
+			// weird disproportionate measures if the grid has set
+			// column widths, but no full grid width set
+			var colSizes = colNodes.map(function(colNode){
+				return colNode.offsetWidth;
+			});
+
+			// Set a baseline size for each column based on
+			// its original measure
+			colNodes.forEach(function(colNode, i){
+				this.resizeColumnWidth(colNode.columnId, colSizes[i]);
 			}, this);
 
 			this._resizedColumns = true;


### PR DESCRIPTION
This is a problem if the columns have default sizes, but the grid itself
doesn't. The tables will render out widths proportionate to the CSS requested
widths, but will typically be much larger. Then, as the code loops, the new
width on the first node causes it to be disporportionately larger than the
others, which all get crushed down quite significantly, meaning that on that
first resize, your first column gets much larger, even if you were shrinking
it.
