### PR TITLE
remove loadingNode when queries are canceled

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -102,7 +102,12 @@ return declare([List, _StoreMixin], {
 		var loadingNode = put(preloadNode, "-div.dgrid-loading"),
 			innerNode = put(loadingNode, "div.dgrid-below");
 		innerNode.innerHTML = this.loadingMessage;
-		
+
+		function rethrow(e) {
+			put(loadingNode, "!");
+			throw e;
+		}
+
 		// Establish query options, mixing in our own.
 		// (The getter returns a delegated object, so simply using mixin is safe.)
 		options = lang.mixin(this.get("queryOptions"), options, 
@@ -141,8 +146,8 @@ return declare([List, _StoreMixin], {
 				self._processScroll(); // recheck the scroll position in case the query didn't fill the screen
 				// can remove the loading node now
 				return trs;
-			});
-		});
+			}, rethrow);
+		}, rethrow);
 
 		// return results so that callers can handle potential of async error
 		return results;
@@ -404,6 +409,9 @@ return declare([List, _StoreMixin], {
 						}
 						// make sure we have covered the visible area
 						grid._processScroll();
+					}, function (e) {
+						put(loadingNode, "!");
+						throw e;
 					});
 				}).call(this, loadingNode, scrollNode, below, keepScrollTo, results);
 				preload = preload.previous;

--- a/extensions/Pagination.js
+++ b/extensions/Pagination.js
@@ -269,6 +269,7 @@ function(_StoreMixin, declare, lang, Deferred, on, query, string, has, put, i18n
 						grid.resize();
 					}
 				}, function(error){
+					put(loadingNode, "!");
 					// enable loading again before throwing the error
 					delete grid._isLoading;
 					throw error;


### PR DESCRIPTION
it looks like it could be possible that the `loadingNode` may not be cleared when some of the Deferreds cancel (or reject).

it's possible that `loadingNode` is actually being cleared some other way and so i'm not sure this is necessary - maybe it's more of a theoretical issue than a real one.  i tried to build a test case that would show this issue but was never able to make it happen (32e147b - that particular commit obviously won't fail because it was applied after the fix but that's the code i had been using if you care to cherry-pick it for yourself locally).

i'd be ok if you don't take this or you want to take some time to look at it before you accept it.  i really would have liked to have made a failing test case or have a way to explain why the case won't fail.
