### PR TITLE
small optimization to call put with an array

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -243,10 +243,7 @@ return declare([List, _StoreMixin], {
 					preloadNode.style.height = (preloadNode.offsetHeight + reclaimedHeight) + "px";
 				}
 				// we remove the elements after expanding the preload node so that the contraction doesn't alter the scroll position
-				var trashBin = put("div");
-				for(var i = 0; i < toDelete.length; i++){
-					put(trashBin, toDelete[i]); // remove it from the DOM
-				}
+				var trashBin = put("div", toDelete);
 				setTimeout(function(){
 					// we can defer the destruction until later
 					put(trashBin, "!");


### PR DESCRIPTION
a minor optimization since put-selector can take an array of nodes and place them as children of a parent - `put(parent, nodes);`
