### PR TITLE
Ability to override default cell rendering behavior in grid sub-classes

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -159,7 +159,7 @@ function(kernel, declare, listen, has, put, List){
 					// A column can provide a renderCell method to do its own DOM manipulation, 
 					// event handling, etc.
 					appendIfNode(td, column.renderCell(object, data, td, options));
-				}else if (self.defaultRenderCell){
+				}else if(self.defaultRenderCell){
 					appendIfNode(td, self.defaultRenderCell(object, data, td, options));
 				}else{
 					appendIfNode(td, Grid.defaultRenderCell(object, data, td, options));


### PR DESCRIPTION
Hi - we have many grids in our application, and all share default cell rendering behaviour.

Our cases include such things as the default rendering of numeric and date values in particular formats.

With this in mind, I've changed `Grid.renderRow` to check for the existence of `self.defaultRenderCell` and use it in the absence of a column `renderCell` function.

I've also changed the code to use `Grid.defaultRenderCell` as its fallback rather than repeating that code.
