### PR TITLE
Add .dgrid-cell-editing class when editor is active.

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -222,6 +222,9 @@ function createSharedEditor(column, originalRenderCell){
 		// Remove the editor from the cell, to be reused later.
 		parentNode.removeChild(node);
 		
+		// Remove the cell editing class
+		put(cell.element, '!dgrid-cell-editing');
+		
 		// Clear out the rest of the cell's contents, then re-render with new value.
 		while(i--){ put(parentNode.firstChild, "!"); }
 		Grid.appendIfNode(parentNode, column.renderCell(
@@ -269,6 +272,9 @@ function showEditor(cmp, column, cellElement, value){
 	
 	cellElement.innerHTML = "";
 	put(cellElement, cmp.domNode || cmp);
+	
+	// Add cell editing class
+	put(cellElement, '.dgrid-cell-editing');
 	
 	if(isWidget){
 		// For widgets, ensure startup is called before setting value,


### PR DESCRIPTION
Small change to add a class when an editor is shown.
