### PR TITLE
When _destroyColumns is called, deselection should occur if necessary.

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -420,7 +420,7 @@ return declare(null, {
 	},
 	
 	refresh: function(){
-		if(this.deselectOnRefresh && !this._columnsDestroyed){
+		if(this.deselectOnRefresh){
 			this.clearSelection();
 			// Need to fire the selection event now because after the refresh,
 			// the nodes that we will fire for will be gone.
@@ -437,16 +437,12 @@ return declare(null, {
 			this._fireSelectionEvent && this._fireSelectionEvent();
 		}
 		
-		this._columnsDestroyed = true;
-		
 		this.inherited(arguments);
 	},
 	
 	renderArray: function(){
 		var grid = this,
 			rows = this.inherited(arguments);
-			
-		this._columnsDestroyed = false;
 		
 		Deferred.when(rows, function(rows){
 			var selection = grid.selection,


### PR DESCRIPTION
If _destroyColumns is called before Selection.deselect, an error will occur as the row data will be deleted.
