### PR TITLE
Fix #441: Prevent un-necessary events in ColumnResizer

### DIFF
--- a/extensions/ColumnResizer.js
+++ b/extensions/ColumnResizer.js
@@ -85,7 +85,7 @@ function resizeColumnWidth(grid, colId, width, parentType){
 		event.parentType = parentType;
 	}
 	
-	if(listen.emit(grid.headerNode, "dgrid-columnresize", event)){
+	if(grid._resizedColumns && listen.emit(grid.headerNode, "dgrid-columnresize", event)){
 		// Update width on column object, then convert value for CSS
 		if(width === "auto"){
 			delete column.width;


### PR DESCRIPTION
When the grid has a column resized for the first time, the `resizeColumnWidth` method is called on all columns in the grid. This was causing the "dgrid-columnresize" event to fire on unaffected columns. This change prevents these events from being emitted.
