### PR TITLE
ColumnSet Pagination compatibility fix

### DIFF
--- a/ColumnSet.js
+++ b/ColumnSet.js
@@ -37,7 +37,7 @@ function(kernel, declare, Deferred, listen, aspect, query, has, miscUtil, put, h
 			contentWidth = columnSetElement.firstChild.offsetWidth;
 			scrollerContents[i].style.width = contentWidth + "px";
 			scrollers[i].style.width = scrollerWidth + "px";
-			scrollers[i].style.bottom = grid.showFooter ? "20px" : "0px";
+			scrollers[i].style.bottom = grid.showFooter ? grid.footerNode.offsetHeight + "px" : "0px";
 			// IE seems to need scroll to be set explicitly
 			scrollers[i].style.overflowX = contentWidth > scrollerWidth ? "scroll" : "auto";
 			scrollers[i].style.left = left + "px";


### PR DESCRIPTION
When a footerNode is being shown (via pagination or otherwise), ColumnSets attempts to put the scrollbar above the footerNode.
