### PR TITLE
Correction to List startup method

### DIFF
--- a/List.js
+++ b/List.js
@@ -225,9 +225,9 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 			// summary:
 			//		Called automatically after postCreate if the component is already
 			//		visible; otherwise, should be called manually once placed.
-			
+
+            if(this._started){ return; } // prevent double-triggering
 			this.inherited(arguments);
-			if(this._started){ return; } // prevent double-triggering
 			this._started = true;
 			this.resize();
 			// apply sort (and refresh) now that we're ready to render


### PR DESCRIPTION
Currently, the List calls its ancestors' startup methods _before_ it
checks to see if it is started. If any of its ancestors set _started to
true, List's own startup method never actually runs. This is not correct
behaviour.

The right thing to do is to check to see if _started is set first. This
is how it is done in DijitRegistry.

This can be a problem if List is used as a mixin with some other
implementor of the startup method. The ordering of List and this other
mixin will change how List starts up, which isn't appropriate.

This change will make List behave in a more consistent and reliable way.
