### PR TITLE
Set defaultChecked property of checkbox and radio buttons

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -18,7 +18,7 @@ function updateInputValue(input, value){
 	// common code for updating value of a standard input
 	input.value = value;
 	if(input.type == "radio" || input.type == "checkbox"){
-		input.checked = input.defaultChecked = value;
+		input.checked = input.defaultChecked = !!value;
 	}
 }
 


### PR DESCRIPTION
Fixes issue in IE7- where checkboxes were not being checked by default.
