### PR TITLE
Passing value through when selecting via `toCell`

### DIFF
--- a/CellSelection.js
+++ b/CellSelection.js
@@ -99,7 +99,7 @@ return declare(Selection, {
 					// and now loop through each column to be selected
 					for(i = 0; i < columnIds.length; i++){
 						cell = this.cell(nextNode, columnIds[i]);
-						this.select(cell);
+						this.select(cell, null, value);
 					}
 					if(nextNode == toElement){
 						break;


### PR DESCRIPTION
When using the `toCell` parameter, it's not properly passing the
`value` argument through to the cell selections, so deselection
doesn't reliably work. This simple change looks to fix that.
