### PR TITLE
add DijitRegistry#getParent

### DIFF
--- a/extensions/DijitRegistry.js
+++ b/extensions/DijitRegistry.js
@@ -71,6 +71,13 @@ function(declare, domGeometry, registry){
 			// summary:
 			//		dgrid doesn't support watch; this is a no-op for compatibility with
 			//		some Dijit layout widgets which assume its existence.
-		}
+		},
+		
+		getParent: function() {
+			// summary:
+			//		Analogue of _WidgetBase#getParent for compatibility with for example
+			//		dijit._KeyNavContainer.		  
+		  return registry.getEnclosingWidget(this.domNode.parentNode);
+		}		
 	});
 });


### PR DESCRIPTION
pls. add DijitRegistry#getParent for compatibility with dijit._KeyNavContainer

this is the code in dijit._KeyNavContainer

```
        childSelector: function(/*DOMNode*/ node){
            // Implement _KeyNavMixin.childSelector, to identify focusable child nodes.
            // If we allowed a dojo/query dependency from this module this could more simply be a string "> *"
            // instead of this function.

            var node = registry.byNode(node);
            return node && node.getParent() == this;
        }
```

Grid is received from registry, but it doesn't provide getParent(). Any _WidgetBase descendant would provide getParent().
