### PR TITLE
Fix #545 onSelect should check grid.allowSelect.

### DIFF
--- a/selector.js
+++ b/selector.js
@@ -64,6 +64,11 @@ function(kernel, arrayUtil, on, aspect, has, put){
 			if(event.type == "click" || event.keyCode == 32 || (!has("opera") && event.keyCode == 13) || event.keyCode === 0){
 				var row = grid.row(event),
 					lastRow = grid._lastSelected && grid.row(grid._lastSelected);
+
+				if (!grid.allowSelect(row)) {
+					return;
+				}
+
 				grid._selectionTriggerEvent = event;
 				
 				if(type == "radio"){


### PR DESCRIPTION
If grid.allowSelect returns false, onSelect should not do anything.
