### PR TITLE
Fix #524

### DIFF
--- a/extensions/ColumnHider.js
+++ b/extensions/ColumnHider.js
@@ -216,34 +216,21 @@ function(declare, has, listen, miscUtil, put){
 			
 			// Use miscUtil function directly, since we clean these up ourselves anyway
 			var selectorPrefix = "#" + miscUtil.escapeCssIdentifier(this.domNode.id) + " .dgrid-column-",
-				next, rules, i; // used in IE8 code path
+				tableRule; // used in IE8 code path
 
 			if (this._columnHiderRules[id]) {
 				return;
 			}
-			
+
+			this._columnHiderRules[id] =
+				miscUtil.addCssRule(selectorPrefix + id, "display: none;");
+
 			if(has("ie") === 8 && !has("quirks")){
-				// Avoid inconsistent behavior in IE8 when display: none is set on a cell
-				next = this.column(id).headerNode.nextSibling;
-				
-				rules = [ miscUtil.addCssRule(selectorPrefix + id,
-					"width: 0 !important; white-space: nowrap !important; padding: 0 !important; margin: 0 !important; border: none !important;")
-				];
-				
-				if(next && (next = this.column(next)) && (next = next.id)){
-					// Also remove left border on next sibling if one exists, to avoid
-					// width issues due to borders not collapsing
-					rules.push(miscUtil.addCssRule(selectorPrefix + next, "border-left: none !important;"));
-				}
-				
-				this._columnHiderRules[id] = {
-					remove: function(){
-						for(i = rules.length; i--;){ rules[i].remove(); }
-					}
-				};
-			}else{
-				this._columnHiderRules[id] =
-					miscUtil.addCssRule(selectorPrefix + id, "display: none;");
+				tableRule = miscUtil.addCssRule(".dgrid-row-table", "display: inline-table;");
+
+				window.setTimeout(function(){
+					tableRule.remove();
+				}, 0);
 			}
 		},
 		


### PR DESCRIPTION
Temporarily change CSS "display" property of tables to force them to re-render with correct column widths in IE8
