### PR TITLE
Fix #533 Selector events after postCreate.

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -129,6 +129,8 @@ return declare(null, {
 	//		setting this property to either true or false will explicitly set the
 	//		behavior regardless of selectionMode.
 	allowTextSelection: undefined,
+
+	_selectionEventsInitialized: false,
 	
 	create: function(){
 		this.selection = {};
@@ -318,6 +320,8 @@ return declare(null, {
 				if(row && (row.id in this.selection)){ this.deselect(rowElement); }
 			}
 		});
+
+		this._selectionEventsInitialized = true;
 	},
 	
 	allowSelect: function(row){

--- a/selector.js
+++ b/selector.js
@@ -97,10 +97,14 @@ function(kernel, arrayUtil, on, aspect, has, put){
 		function setupSelectionEvents(){
 			// register one listener at the top level that receives events delegated
 			grid._hasSelectorInputListener = true;
-			listeners.push(aspect.before(grid, "_initSelectionEvents", function(){
-				// listen for clicks and keydown as the triggers
-				this.on(".dgrid-selector:click,.dgrid-selector:keydown", onSelect);
-			}));
+			if (grid._selectionEventsInitialized) {
+				listeners.push(grid.on(".dgrid-selector:click,.dgrid-selector:keydown", onSelect));
+			} else {
+				listeners.push(aspect.before(grid, "_initSelectionEvents", function(){
+					// listen for clicks and keydown as the triggers
+					this.on(".dgrid-selector:click,.dgrid-selector:keydown", onSelect);
+				}));
+			}
 			var handleSelect = grid._handleSelect;
 			grid._handleSelect = function(event){
 				// ignore the default select handler for events that originate from the selector column


### PR DESCRIPTION
If selection events have already been initialized, we do not need to aspect.after Selection._initSelectionEvents
