### PR TITLE
Remove unneeded class application on column set scrollbar div:

### DIFF
--- a/ColumnSet.js
+++ b/ColumnSet.js
@@ -182,7 +182,7 @@ function(kernel, declare, Deferred, listen, aspect, query, has, miscUtil, put, h
 			function putScroller(columnSet, i){
 				// function called for each columnSet
 				var scroller = scrollers[i] =
-					put(domNode, "div.dgrid-column-set-scroller.dgrid-scrollbar-height.dgrid-column-set-scroller-" + i +
+					put(domNode, "div.dgrid-column-set-scroller.dgrid-column-set-scroller-" + i +
 						"[" + colsetidAttr + "=" + i +"]");
 				scrollerContents[i] = put(scroller, "div.dgrid-column-set-scroller-content");
 				listen(scroller, "scroll", onScroll);


### PR DESCRIPTION
**Bug that this fixes:**
Using Set 2 of the third grid on @test/complex_column.html@, there is an invisible scrollbar div that blocks user clicks at the bottom of the right grid section. 

This fix was verified not to break existing column set functionality from IE6 up.
