### PR TITLE
Issue-574 Row selection lost during realtime update

### DIFF
--- a/List.js
+++ b/List.js
@@ -428,7 +428,7 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 									firstRow.rowIndex--; // adjust the rowIndex so adjustRowIndices has the right starting point
 								}
 							}
-							self.removeRow(row); // now remove
+							self.removeRow(row, from === to); // now remove
 						}
 						// the removal of rows could cause us to need to page in more items
 						if(self._processScroll){


### PR DESCRIPTION
When a row is updated via dojo Observerable pattern, the updated row will lose selection.

Fixes #574

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
