### PR TITLE
Issue-577 Pagination: Incorrect "rowsPerPage" displayed on startup

### DIFF
--- a/extensions/Pagination.js
+++ b/extensions/Pagination.js
@@ -93,7 +93,7 @@ function(_StoreMixin, declare, lang, Deferred, on, query, string, has, put, i18n
 				var sizeSelect = put(paginationNode, 'select.dgrid-page-size'),
 					i;
 				for(i = 0; i < pageSizeOptions.length; i++){
-					put(sizeSelect, 'option', pageSizeOptions[i], {value: pageSizeOptions[i]});
+					put(sizeSelect, 'option', pageSizeOptions[i], {value: pageSizeOptions[i], selected: this.rowsPerPage === pageSizeOptions[i]});
 				}
 				this._listeners.push(on(sizeSelect, "change", function(){
 					grid.rowsPerPage = +sizeSelect.value;


### PR DESCRIPTION
With the following settings:
rowsPerPage: 50,
pageSizeOptions: [25, 50, 100]

The default selection in the displayed drop list is still 25.

Fixes #577

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
