### PR TITLE
Fix #597 - Down arrow key problem in Firefox 23/24

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -110,7 +110,8 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 							(extraClassName ? "." + extraClassName : "")
 						).replace(invalidClassChars,"-") +
 						"[role=" + (tag === "th" ? "columnheader" : "gridcell") + "]");
-					cell.columnId = id;
+					if (typeof Object.defineProperty == 'function') Object.defineProperty(cell, "columnId", {value: id});					
+					else cell.columnId = id;
 					if(contentBoxSizing){
 						// The browser (IE7-) does not support box-sizing: border-box, so we emulate it with a padding div
 						innerCell = put(cell, "!dgrid-cell-padding div.dgrid-cell-padding");// remove the dgrid-cell-padding, and create a child with that class


### PR DESCRIPTION
There is a problem in Firefox 23/24 when using simple assignment like cell.columnId = id to define property to dom objects.  Use Object.defineProperty does not have such problem.  So use this whenever Object.defineProperty exists. 
