### PR TITLE
ColumnSet lacks ARIA roles, breaks JAWS

### DIFF
--- a/ColumnSet.js
+++ b/ColumnSet.js
@@ -133,11 +133,11 @@ function(kernel, declare, Deferred, listen, aspect, query, has, miscUtil, put, h
 		},
 		columnSets: [],
 		createRowCells: function(tag, each){
-			var row = put("table.dgrid-row-table[row=presentation]");
-			var tr = put(row, "tbody tr[row=presentation]");
+			var row = put("table.dgrid-row-table[role=presentation]");
+			var tr = put(row, "tbody tr[role=presentation]");
 			for(var i = 0, l = this.columnSets.length; i < l; i++){
 				// iterate through the columnSets
-				var cell = put(tr, tag + ".dgrid-column-set-cell.dgrid-column-set-" + i + "[row=presentation]" +
+				var cell = put(tr, tag + ".dgrid-column-set-cell.dgrid-column-set-" + i + "[role=presentation]" +
 					" div.dgrid-column-set[" + colsetidAttr + "=" + i + "]");
 				cell.appendChild(this.inherited(arguments, [tag, each, this.columnSets[i]]));
 			}


### PR DESCRIPTION
The ColumnSet mixin isn't providing ARIA roles for the DOM it's creating, and this is apparently causing JAWS to skip reading the content contained therein.

I'm not terribly familiar with all the nuances of ARIA roles, but from my reading of the spec, I would've thought that all it would take is adding `[role=presentation]` to the `.dgrid-row-table` node created in `createRowCells()`. However, the testing team I'm working with reports that this isn't sufficient, and that JAWS isn't reading the content until we add `[role=presentation]` to some other nodes created by this mixin. After that's done, JAWS is apparently perfectly happy.

I have no way of testing this here on my machine at this point, so I can't verify the accuracy of the findings, but I've prepared a pull request with the changes anyway, if only to kick off a discussion.

(apologies for the proxy submission; this is coming from a project for a client who's not particularly GitHub-savvy)
