### PR TITLE
Updated the test ordered store to handle moving items to the end of the collection.

### DIFF
--- a/test/data/base.js
+++ b/test/data/base.js
@@ -261,7 +261,7 @@ function(lang, Deferred, Memory, Observable, QueryResults){
 		return Observable(new Memory(lang.mixin({data: data,
 			idProperty: "name",
 			put: function(object, options){
-                object.order = calculateOrder(this, object, options && options.before);
+				object.order = calculateOrder(this, object, options && options.before);
 				return Memory.prototype.put.call(this, object, options);
 			},
 			// Memory's add does not need to be augmented since it calls put


### PR DESCRIPTION
The test ordered store was not handling a missing options.before in the put method. This can occur when an item is moved to the end of the list.
