### PR TITLE
Add German translation to pagination extension

### DIFF
--- a/extensions/nls/de/pagination.js
+++ b/extensions/nls/de/pagination.js
@@ -1,0 +1,9 @@
+define({
+		status: "${start} - ${end} von ${total} Ergebnissen",
+		gotoFirst: "Gehe zu erster Seite",
+		gotoNext: "Gehe zu nächster Seite",
+		gotoPrev: "Gehe zu vorheriger Seite",
+		gotoLast: "Gehe zu letzter Seite",
+		gotoPage: "Gehe zu Seite",
+		jumpPage: "Springe zu Seite"
+});

--- a/extensions/nls/pagination.js
+++ b/extensions/nls/pagination.js
@@ -12,5 +12,6 @@ define({
 	fr: true,
 	pt: true,
 	ja: true,
-	sk: true
+	sk: true,
+	de: true
 });


### PR DESCRIPTION
Adds German/'de' i18n/nls entries for the pagination extension.

I consider this to be trivial enough not to require a Dojo CLA.
