### PR TITLE
Fix #603: editor throwing error on blur event

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -244,6 +244,7 @@ function createSharedEditor(column, originalRenderCell){
 			bubbles: true,
 			cancelable: false
 		});
+		column._editorBlurHandle.pause();
 		// Remove the editor from the cell, to be reused later.
 		parentNode.removeChild(node);
 		
@@ -257,7 +258,6 @@ function createSharedEditor(column, originalRenderCell){
 		
 		// reset state now that editor is deactivated
 		activeCell = activeValue = activeOptions = null;
-		column._editorBlurHandle.pause();
 	}
 	
 	function dismissOnKey(evt){


### PR DESCRIPTION
When the node is removed it is triggering another blur event. Fix by
Pausing the blur event before the child is rmeoved
