### PR TITLE
Fix #361: OnDemandList: empty preload node caused preload processing to stop.

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -422,123 +422,124 @@ return declare([List, _StoreMixin], {
 				count = Math.min(Math.max(count, grid.minRowsPerPage),
 									grid.maxRowsPerPage, preload.count);
 				if(count == 0){
-					return;
-				}
-				count = Math.ceil(count);
-				offset = Math.min(Math.floor(offset), preload.count - count);
-				var options = lang.mixin(grid.get("queryOptions"), preload.options);
-				preload.count -= count;
-				var beforeNode = preloadNode,
-					keepScrollTo, queryRowsOverlap = grid.queryRowsOverlap,
-					below = preloadNode.rowIndex > 0 && preload; 
-				if(below){
-					// add new rows below
-					var previous = preload.previous;
-					if(previous){
-						removeDistantNodes(previous, visibleTop - (previous.node.offsetTop + previous.node.offsetHeight), 'nextSibling');
-						if(offset > 0 && previous.node == preloadNode.previousSibling){
-							// all of the nodes above were removed
-							offset = Math.min(preload.count, offset);
-							preload.previous.count += offset;
-							adjustHeight(preload.previous, true);
-							preloadNode.rowIndex += offset;
-							queryRowsOverlap = 0;
-						}else{
-							count += offset;
-						}
-						preload.count -= offset;
-					}
-					options.start = preloadNode.rowIndex - queryRowsOverlap;
-					options.count = Math.min(count + queryRowsOverlap, grid.maxRowsPerPage);
-					preloadNode.rowIndex = options.start + options.count;
+					preload = preload.next;
 				}else{
-					// add new rows above
-					if(preload.next){
-						// remove out of sight nodes first
-						removeDistantNodes(preload.next, preload.next.node.offsetTop - visibleBottom, 'previousSibling', true);
-						var beforeNode = preloadNode.nextSibling;
-						if(beforeNode == preload.next.node){
-							// all of the nodes were removed, can position wherever we want
-							preload.next.count += preload.count - offset;
-							preload.next.node.rowIndex = offset + count;
-							adjustHeight(preload.next);
-							preload.count = offset;
-							queryRowsOverlap = 0;
-						}else{
-							keepScrollTo = true;
+					count = Math.ceil(count);
+					offset = Math.min(Math.floor(offset), preload.count - count);
+					var options = lang.mixin(grid.get("queryOptions"), preload.options);
+					preload.count -= count;
+					var beforeNode = preloadNode,
+						keepScrollTo, queryRowsOverlap = grid.queryRowsOverlap,
+						below = preloadNode.rowIndex > 0 && preload;
+					if(below){
+						// add new rows below
+						var previous = preload.previous;
+						if(previous){
+							removeDistantNodes(previous, visibleTop - (previous.node.offsetTop + previous.node.offsetHeight), 'nextSibling');
+							if(offset > 0 && previous.node == preloadNode.previousSibling){
+								// all of the nodes above were removed
+								offset = Math.min(preload.count, offset);
+								preload.previous.count += offset;
+								adjustHeight(preload.previous, true);
+								preloadNode.rowIndex += offset;
+								queryRowsOverlap = 0;
+							}else{
+								count += offset;
+							}
+							preload.count -= offset;
 						}
-						
+						options.start = preloadNode.rowIndex - queryRowsOverlap;
+						options.count = Math.min(count + queryRowsOverlap, grid.maxRowsPerPage);
+						preloadNode.rowIndex = options.start + options.count;
+					}else{
+						// add new rows above
+						if(preload.next){
+							// remove out of sight nodes first
+							removeDistantNodes(preload.next, preload.next.node.offsetTop - visibleBottom, 'previousSibling', true);
+							var beforeNode = preloadNode.nextSibling;
+							if(beforeNode == preload.next.node){
+								// all of the nodes were removed, can position wherever we want
+								preload.next.count += preload.count - offset;
+								preload.next.node.rowIndex = offset + count;
+								adjustHeight(preload.next);
+								preload.count = offset;
+								queryRowsOverlap = 0;
+							}else{
+								keepScrollTo = true;
+							}
+
+						}
+						options.start = preload.count;
+						options.count = Math.min(count + queryRowsOverlap, grid.maxRowsPerPage);
 					}
-					options.start = preload.count;
-					options.count = Math.min(count + queryRowsOverlap, grid.maxRowsPerPage);
-				}
-				if(keepScrollTo && beforeNode && beforeNode.offsetWidth){
-					keepScrollTo = beforeNode.offsetTop;
-				}
+					if(keepScrollTo && beforeNode && beforeNode.offsetWidth){
+						keepScrollTo = beforeNode.offsetTop;
+					}
 
-				adjustHeight(preload);
-				// create a loading node as a placeholder while the data is loaded
-				var loadingNode = put(beforeNode, "-div.dgrid-loading[style=height:" + count * grid.rowHeight + "px]"),
-					innerNode = put(loadingNode, "div.dgrid-" + (below ? "below" : "above"));
-				innerNode.innerHTML = grid.loadingMessage;
-				loadingNode.count = count;
-				// use the query associated with the preload node to get the next "page"
-				options.query = preload.query;
-				// Query now to fill in these rows.
-				// Keep _trackError-wrapped results separate, since if results is a
-				// promise, it will lose QueryResults functions when chained by `when`
-				var results = preload.query(options),
-					trackedResults = grid._trackError(function(){ return results; });
-				
-				if(trackedResults === undefined){
-					// Sync query failed
-					put(loadingNode, "!");
-					return;
-				}
+					adjustHeight(preload);
+					// create a loading node as a placeholder while the data is loaded
+					var loadingNode = put(beforeNode, "-div.dgrid-loading[style=height:" + count * grid.rowHeight + "px]"),
+						innerNode = put(loadingNode, "div.dgrid-" + (below ? "below" : "above"));
+					innerNode.innerHTML = grid.loadingMessage;
+					loadingNode.count = count;
+					// use the query associated with the preload node to get the next "page"
+					options.query = preload.query;
+					// Query now to fill in these rows.
+					// Keep _trackError-wrapped results separate, since if results is a
+					// promise, it will lose QueryResults functions when chained by `when`
+					var results = preload.query(options),
+						trackedResults = grid._trackError(function(){ return results; });
 
-				// Isolate the variables in case we make multiple requests
-				// (which can happen if we need to render on both sides of an island of already-rendered rows)
-				(function(loadingNode, scrollNode, below, keepScrollTo, results){
-					lastRows = Deferred.when(grid.renderArray(results, loadingNode, options), function(rows){
-						lastResults = results;
-						
-						// can remove the loading node now
-						beforeNode = loadingNode.nextSibling;
+					if(trackedResults === undefined){
+						// Sync query failed
 						put(loadingNode, "!");
-						if(keepScrollTo && beforeNode && beforeNode.offsetWidth){ // beforeNode may have been removed if the query results loading node was a removed as a distant node before rendering 
-							// if the preload area above the nodes is approximated based on average
-							// row height, we may need to adjust the scroll once they are filled in
-							// so we don't "jump" in the scrolling position
-							var pos = grid.getScrollPosition();
-							grid.scrollTo({
-								// Since we already had to query the scroll position,
-								// include x to avoid TouchScroll querying it again on its end.
-								x: pos.x,
-								y: pos.y + beforeNode.offsetTop - keepScrollTo,
-								// Don't kill momentum mid-scroll (for TouchScroll only).
-								preserveMomentum: true
-							});
-						}
-						if(below){
-							// if it is below, we will use the total from the results to update
-							// the count of the last preload in case the total changes as later pages are retrieved
-							// (not uncommon when total counts are estimated for db perf reasons)
-							Deferred.when(results.total || results.length, function(total){
-								// recalculate the count
-								below.count = total - below.node.rowIndex;
-								// readjust the height
-								adjustHeight(below);
-							});
-						}
-						// make sure we have covered the visible area
-						grid._processScroll();
-						return rows;
-					}, function (e) {
-						put(loadingNode, "!");
-						throw e;
-					});
-				}).call(this, loadingNode, scrollNode, below, keepScrollTo, results);
-				preload = preload.previous;
+						return;
+					}
+
+					// Isolate the variables in case we make multiple requests
+					// (which can happen if we need to render on both sides of an island of already-rendered rows)
+					(function(loadingNode, scrollNode, below, keepScrollTo, results){
+						lastRows = Deferred.when(grid.renderArray(results, loadingNode, options), function(rows){
+							lastResults = results;
+
+							// can remove the loading node now
+							beforeNode = loadingNode.nextSibling;
+							put(loadingNode, "!");
+							if(keepScrollTo && beforeNode && beforeNode.offsetWidth){ // beforeNode may have been removed if the query results loading node was a removed as a distant node before rendering
+								// if the preload area above the nodes is approximated based on average
+								// row height, we may need to adjust the scroll once they are filled in
+								// so we don't "jump" in the scrolling position
+								var pos = grid.getScrollPosition();
+								grid.scrollTo({
+									// Since we already had to query the scroll position,
+									// include x to avoid TouchScroll querying it again on its end.
+									x: pos.x,
+									y: pos.y + beforeNode.offsetTop - keepScrollTo,
+									// Don't kill momentum mid-scroll (for TouchScroll only).
+									preserveMomentum: true
+								});
+							}
+							if(below){
+								// if it is below, we will use the total from the results to update
+								// the count of the last preload in case the total changes as later pages are retrieved
+								// (not uncommon when total counts are estimated for db perf reasons)
+								Deferred.when(results.total || results.length, function(total){
+									// recalculate the count
+									below.count = total - below.node.rowIndex;
+									// readjust the height
+									adjustHeight(below);
+								});
+							}
+							// make sure we have covered the visible area
+							grid._processScroll();
+							return rows;
+						}, function (e) {
+							put(loadingNode, "!");
+							throw e;
+						});
+					}).call(this, loadingNode, scrollNode, below, keepScrollTo, results);
+					preload = preload.previous;
+				}
 			}
 		}
 		


### PR DESCRIPTION
In cases where the first/top preload node was visible but empty, the second/bottom one was not being processed.  The top one had to be scrolled beyond the buffer limit before the second one was processed.
