### PR TITLE
Add option to automatically clean up after styleColumn / styleColumnSet when a new structure is set

### DIFF
--- a/ColumnSet.js
+++ b/ColumnSet.js
@@ -1,5 +1,5 @@
-define(["dojo/_base/kernel", "dojo/_base/declare", "dojo/_base/lang", "dojo/_base/Deferred", "dojo/on", "dojo/aspect", "dojo/query", "dojo/has", "./util/misc", "put-selector/put", "xstyle/has-class", "./Grid", "dojo/_base/sniff", "xstyle/css!./css/columnset.css"],
-function(kernel, declare, lang, Deferred, listen, aspect, query, has, miscUtil, put, hasClass, Grid){
+define(["dojo/_base/kernel", "dojo/_base/declare", "dojo/_base/lang", "dojo/_base/Deferred", "dojo/on", "dojo/aspect", "dojo/query", "dojo/has", "./util/misc", "put-selector/put", "xstyle/has-class", "dojo/_base/sniff", "xstyle/css!./css/columnset.css"],
+function(kernel, declare, lang, Deferred, listen, aspect, query, has, miscUtil, put, hasClass){
 	has.add("event-mousewheel", function(global, document, element){
 		return typeof element.onmousewheel !== "undefined";
 	});
@@ -166,8 +166,8 @@ function(kernel, declare, lang, Deferred, listen, aspect, query, has, miscUtil, 
 		styleColumnSet: function(colsetId, css){
 			// summary:
 			//		Dynamically creates a stylesheet rule to alter a columnset's style.
-			
-			var rule = this.addCssRule("#" + miscUtil.escapeCssIdentifier(this.domNode.id) + " .dgrid-column-set-" + colsetId, css);
+
+			var rule = this._addColumnRule(".dgrid-column-set-" + colsetId, css);
 			this._positionScrollers();
 			return rule;
 		},

--- a/test/intern/all.js
+++ b/test/intern/all.js
@@ -2,9 +2,10 @@ define([
 	'intern/node_modules/dojo/has!host-browser?./core/createDestroy',
 	'intern/node_modules/dojo/has!host-browser?./core/addCssRule',
 	'intern/node_modules/dojo/has!host-browser?./core/setClass',
-	'intern/node_modules/dojo/has!host-browser?./mixins/Keyboard',
-	'intern/node_modules/dojo/has!host-browser?./mixins/Selection',
 	'intern/node_modules/dojo/has!host-browser?./core/stores',
 	'intern/node_modules/dojo/has!host-browser?./core/_StoreMixin',
-	'intern/node_modules/dojo/has!host-browser?./core/OnDemand-removeRow'
+	'intern/node_modules/dojo/has!host-browser?./core/OnDemand-removeRow',
+	'intern/node_modules/dojo/has!host-browser?./mixins/Keyboard',
+	'intern/node_modules/dojo/has!host-browser?./mixins/Selection',
+	'intern/node_modules/dojo/has!host-browser?./mixins/ColumnSet'
 ], function(){});

--- a/test/intern/core/addCssRule.js
+++ b/test/intern/core/addCssRule.js
@@ -1,12 +1,14 @@
 define([
 	"intern!tdd",
 	"intern/assert",
+	"dojo/_base/lang",
+	"dojo/_base/array",
 	"dojo/dom-style",
 	"dojo/dom-construct",
 	"dojo/query",
 	"dgrid/Grid",
 	"dgrid/util/misc"
-], function (test, assert, domStyle, domConstruct, query, Grid, miscUtil) {
+], function (test, assert, lang, array, domStyle, domConstruct, query, Grid, miscUtil) {
 	var testDiv;
 
 	test.suite("addCssRule", function(){
@@ -103,19 +105,21 @@ define([
 
 		test.test("addCssRule via dgrid APIs", function(){
 			var values = ["7px", "8px"],
+				columns = {
+					name: "Name",
+					value: "Value",
+					comment: "Comment" // unstyled buffer
+				},
 				origValues,
-				grid;
+				grid,
+				rules,
+				i;
 			
-			function createGrid(cleanAddedRules){
-				grid = new Grid({
+			function createGrid(config){
+				grid = new Grid(lang.mixin({
 					id: "my.grid", // test escaping of CSS identifiers from methods
-					columns: {
-						name: "Name",
-						value: "Value",
-						comment: "Comment" // unstyled buffer
-					},
-					cleanAddedRules: cleanAddedRules
-				});
+					columns: columns
+				}, config || {}));
 				document.body.appendChild(grid.domNode);
 				grid.startup();
 			}
@@ -136,47 +140,111 @@ define([
 				];
 			}
 			
-			function checkRules(expected){
+			function checkRules(expected, extra){
 				var actual = getStyles(grid);
 				assert.strictEqual(expected[0], actual[0],
-					"Style modified via addCssRule has expected value");
+					(extra || "") + " Style modified via addCssRule has expected value. Expected: " + expected[0] + ", Actual: " + actual[0]);
 				assert.strictEqual(expected[1], actual[1],
-					"Style modified via styleColumn has expected value");
+					(extra || "") + " Style modified via styleColumn has expected value. Expected: " + expected[1] + ", Actual: " + actual[1]);
+			}
+
+			function removeRules(rules){
+				array.forEach(rules,function(rule){
+					rule.remove();
+				});
 			}
 			
-			// Create grid for the first time
-			createGrid(true);
+			// Test if rules are applied
+			createGrid({cleanAddedRules: true, cleanAddedColumnRules: true});
 			// Collect original style values for later cleanup check
 			origValues = getStyles();
 			// Add rules and make sure they applied as expected
 			addRules();
-			checkRules(values);
+			checkRules(values, "1:");
 			// Destroy the grid, which should remove the style rules
 			grid.destroy();
 			
-			// Create grid for the second time, with cleanAddedRules: false
-			createGrid(false);
+			// Create a grid and tell it not to clean rules added via addCssRule.
+			createGrid({cleanAddedRules: false, cleanAddedColumnRules: true});
 			// Before adding styles, make sure the ones from last time were removed
-			checkRules(origValues);
+			checkRules(origValues, "2:");
 			// Add rules and check again;
 			// store the rules for tearDown since they won't be cleaned up
-			this.rules = addRules();
-			checkRules(values);
-			// Destroy the grid, which should *not* remove the style rules
+			rules = addRules();
+			checkRules(values, "3:");
+			// Destroy the grid, which should *not* remove the addCssRule style rules
+			// but should remove the styleColumn rules
 			grid.destroy();
 			
-			// Create grid for the third time
-			createGrid(true);
-			// Check that styles from last time still exist
-			checkRules(values);
+			// Create a grid to see if the styles are still there.
+			createGrid({cleanAddedRules: true, cleanAddedColumnRules: true});
+			// Check that one style from last time still exists
+			checkRules([values[0], origValues[1]], "4:");
 			// Destroy the grid (which won't remove the styles from last time,
 			// since no handles were added to this exact instance)
 			grid.destroy();
 			// Clean up rule litter from cleanAddedRules: false test
-			var i;
-			for(i in this.rules){
-				this.rules[i].remove();
-			}
+			removeRules(rules);
+
+			// Create a grid and tell it not to clean up styles created from styleColumn
+			createGrid({cleanAddedRules: true, cleanAddedColumnRules: false});
+			// Before adding styles, make sure the ones from last time were removed
+			checkRules(origValues, "5:");
+			// Add rules and check again;
+			// store the rules for tearDown since they won't be cleaned up
+			rules = addRules();
+			checkRules(values, "6:");
+			// Destroy the grid, which should *not* remove the styleColumn rules
+			grid.destroy();
+
+			// Create a grid to see if the styleColumn styles are still there.
+			createGrid({cleanAddedRules: true, cleanAddedColumnRules: true});
+			// Check that one style from last time still exists
+			checkRules([origValues[0], values[1]], "7:");
+			// Destroy the grid (which won't remove the styles from last time,
+			// since no handles were added to this exact instance)
+			grid.destroy();
+			// Clean up rule litter from cleanAddedColumnRules: false test
+			removeRules(rules);
+
+			// Create a grid to see if setting the columns clears the styleColumn rules
+			createGrid();
+			// Before adding styles, make sure the ones from last time were removed
+			checkRules(origValues, "8:");
+			// Add rules and make sure they applied as expected
+			rules = addRules();
+			assert.strictEqual(1, grid._columnRules.length);
+			checkRules(values, "9:");
+			// Set the columns to the same definition.
+			grid.set("columns", columns);
+			// The column set rules should have reset.
+			checkRules([values[0], origValues[1]], "10:");
+			// Add rules and make sure they applied as expected
+			addRules();
+			assert.strictEqual(1, grid._columnRules.length);
+			checkRules(values, "11:");
+			// Destroy the grid, which should remove the style rules
+			grid.destroy();
+			createGrid();
+			checkRules(origValues, "12:");
+			grid.destroy();
+
+			// Create a grid to see if setting the columns does not clear the styleColumn rules
+			// when cleanAddedColumnRules is false;
+			createGrid({cleanAddedColumnRules: false});
+			// Before adding styles, make sure the ones from last time were removed
+			checkRules(origValues, "13:");
+			// Add rules and check again;
+			// store the rules for tearDown since they won't be cleaned up
+			rules = addRules();
+			checkRules(values, "14:");
+			// Set the columns to the same definition.
+			grid.set("columns", columns);
+			// The rules should be the same
+			checkRules(values, "15:");
+			// Destroy the grid, which should *not* remove the styleColumn rules
+			grid.destroy();
+			removeRules(rules);
 		});
 	});
 });

--- a/test/intern/mixins/ColumnSet.js
+++ b/test/intern/mixins/ColumnSet.js
@@ -1,0 +1,179 @@
+define([
+	"intern!tdd",
+	"intern/assert",
+	"dojo/_base/declare",
+	"dojo/_base/lang",
+	"dojo/_base/array",
+	"dojo/dom-style",
+	"dojo/dom-construct",
+	"dojo/query",
+	"dgrid/Grid",
+	"dgrid/ColumnSet"
+], function (test, assert, declare, lang, array, domStyle, domConstruct, query, Grid, ColumnSet) {
+	var testDiv;
+
+	function arraysMatch(array1, array2){
+		if(!array1 || !array2 || (array1.length !== array2.length)){
+			return false;
+		}
+		return !array.some(array1, function(item, i){
+			return item !== array2[i];
+		});
+	}
+
+	test.suite("ColumnSet", function(){
+		test.before(function(){
+			testDiv = domConstruct.create("div", null, document.body);
+			domStyle.set(testDiv, "font-size", "19px");
+		});
+
+		test.after(function(){
+			domConstruct.destroy(testDiv);
+		});
+
+		test.test("styleColumnSet", function(){
+			var defaultFontSizes = ["19px", "19px", "19px", "19px", "19px", "19px"],
+				modifiedFontSizes,
+				grid,
+				rules = [],
+				CustomGrid = declare([Grid, ColumnSet]);
+
+			function createGrid(config){
+				grid = new CustomGrid(lang.mixin({
+					id: "my.grid", // test escaping of CSS identifiers from methods
+					columnSets: [
+						[
+							[
+								{label: "Column 1", field: "col1"},
+								{label: "Column 2", field: "col2"}
+							],
+							[
+								{label: "Column 3", field: "col3", colSpan: 2}
+							]
+						],
+						[
+							[
+								{label: "Column 4", field: "col4", rowSpan: 2},
+								{label: "Column 5", field: "col5"}
+							],
+							[
+								{label: "Column 6", field: "col6"}
+							]
+						]]
+				}, config || {}));
+				domConstruct.place(grid.domNode, testDiv);
+				grid.startup();
+			}
+
+			function getFontSizes(){
+				var styles = [];
+				for (var i = 1; i <= 6; i++){
+					styles.push(domStyle.getComputedStyle(query(".field-col" + i, grid.domNode)[0]).fontSize);
+				}
+				return styles;
+			}
+
+			function removeRules(){
+				array.forEach(rules, function(rule){
+					rule.remove();
+				});
+				rules = [];
+			}
+
+			modifiedFontSizes = ["8px", "8px", "8px", "19px", "19px", "19px"];
+			// Create a grid to see if styleColumnSet works.
+			createGrid();
+			// Test the initial font sizes.
+			assert.isTrue(arraysMatch(defaultFontSizes, getFontSizes()), "Expect default values.");
+			// Call styleColumnSet
+			grid.styleColumnSet("0", "font-size: 8px;");
+			// Did it work?
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Destroy the grid, the CSS rules created above should be deleted.
+			grid.destroy();
+
+			// Create a grid with cleanAddedColumnRules set to false.
+			createGrid({cleanAddedColumnRules: false});
+			// Test the initial font sizes.
+			assert.isTrue(arraysMatch(defaultFontSizes, getFontSizes()), "Expect default values.");
+			// Call styleColumnSet
+			rules.push(grid.styleColumnSet("0", "font-size: 8px;"));
+			// Did it work?
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Destroy the grid, the CSS rules should remain
+			grid.destroy();
+			// Create a grid
+			createGrid();
+			// The styles should not be the default.
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Clean up
+			grid.destroy();
+			removeRules();
+
+			// Do it all again but with the second column set.
+
+			modifiedFontSizes = ["19px", "19px", "19px", "8px", "8px", "8px"];
+			// Create a grid to see if styleColumnSet works.
+			createGrid();
+			// Test the initial font sizes.
+			assert.isTrue(arraysMatch(defaultFontSizes, getFontSizes()), "Expect default values.");
+			// Call styleColumnSet
+			grid.styleColumnSet("1", "font-size: 8px;");
+			// Did it work?
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Destroy the grid, the CSS rules created above should be deleted.
+			grid.destroy();
+
+			// Create a grid with cleanAddedColumnRules set to false.
+			createGrid({cleanAddedColumnRules: false});
+			// Test the initial font sizes.
+			assert.isTrue(arraysMatch(defaultFontSizes, getFontSizes()), "Expect default values.");
+			// Call styleColumnSet
+			rules.push(grid.styleColumnSet("1", "font-size: 8px;"));
+			// Did it work?
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Destroy the grid, the CSS rules should remain
+			grid.destroy();
+			// Create a grid
+			createGrid();
+			// The styles should not be the default.
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Clean up
+			grid.destroy();
+			removeRules();
+
+			// Do it all again but with the both column sets.
+			modifiedFontSizes = ["9px", "9px", "9px", "8px", "8px", "8px"];
+			// Create a grid to see if styleColumnSet works.
+			createGrid();
+			// Test the initial font sizes.
+			assert.isTrue(arraysMatch(defaultFontSizes, getFontSizes()), "Expect default values.");
+			// Call styleColumnSet
+			grid.styleColumnSet("0", "font-size: 9px;");
+			grid.styleColumnSet("1", "font-size: 8px;");
+			// Did it work?
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Destroy the grid, the CSS rules created above should be deleted.
+			grid.destroy();
+
+			// Create a grid with cleanAddedColumnRules set to false.
+			createGrid({cleanAddedColumnRules: false});
+			// Test the initial font sizes.
+			assert.isTrue(arraysMatch(defaultFontSizes, getFontSizes()), "Expect default values.");
+			// Call styleColumnSet
+			rules.push(grid.styleColumnSet("0", "font-size: 9px;"));
+			rules.push(grid.styleColumnSet("1", "font-size: 8px;"));
+			// Did it work?
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Destroy the grid, the CSS rules should remain
+			grid.destroy();
+			// Create a grid
+			createGrid();
+			// The styles should not be the default.
+			assert.isTrue(arraysMatch(modifiedFontSizes, getFontSizes()), "Expect all fields in the first column set to have a font size of 8px.");
+			// Clean up
+			grid.destroy();
+			removeRules();
+		});
+	});
+});


### PR DESCRIPTION
CSS rules created by `Grid#styleColumn` and `ColumnSet#styleColumnSet` are managed separately from rules created by `List#addCssRule`.  Column CSS rules are now removed when `Grid#_destroyColumns` is called.  Other than when the widget is destroyed, setting new column, column set or subrow definitions will reset the column styles.  

Included are some Intern tests for `styleColumn` and `styleColumnSet`.
