### PR TITLE
Fix #715: Selection lost when update recorded

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -346,7 +346,7 @@ return declare(null, {
 		if(store && store.notify){
 			this._deselectionSignal = aspect.after(store, "notify", function(object, idToUpdate){
 				var id = idToUpdate || (object && object[this.idProperty || "id"]);
-				if (id) {
+				if (id != null) {
 					var row = self.row(id),
 						selection = row && self.selection[row.id];
 					// Is the row currently in the selection list.


### PR DESCRIPTION
Selection becoming lost when first row (id=0) is selected. A row id check was
only checking for a truthy value
