### PR TITLE
Only show end link if its page number is greater than start.

### DIFF
--- a/extensions/Pagination.js
+++ b/extensions/Pagination.js
@@ -178,7 +178,9 @@ function(_StoreMixin, declare, lang, Deferred, on, query, string, has, put, i18n
 					put(linksNode, "span.dgrid-page-skip", "...");
 				}
 				// last link
-				pageLink(end);
+				if (end > start) {
+					pageLink(end);
+				}
 			}else if(grid.pagingTextBox){
 				// The pageLink function is also used to create the paging textbox.
 				pageLink(currentPage);


### PR DESCRIPTION
Simple but effective.
