### PR TITLE
Fix #713: Add cleanupObservers flag to List

### DIFF
--- a/List.js
+++ b/List.js
@@ -125,6 +125,13 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 		//		incorporate logic from the TouchScroll module (at the expense of
 		//		normal desktop/mouse or native mobile scrolling functionality).
 		useTouchScroll: true,
+
+		// cleanupObservers: Boolean
+		//		Whether to cleanup the observers.
+		//		There exists an issue where the use of the tree column plugin
+		//		will add an observer for the children query, which will cause
+		//		the observer to be removed and not replaced for the grid query.
+		cleanupObservers: true,
 		
 		postscript: function(params, srcNodeRef){
 			// perform setup and invoke create in postScript to allow descendants to
@@ -536,7 +543,7 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 				return lastRow;
 			}
 			function whenError(error){
-				if(typeof observerIndex !== "undefined"){
+				if(self.cleanupObservers && typeof observerIndex !== "undefined"){
 					observers[observerIndex].cancel();
 					observers[observerIndex] = 0;
 					self._numObservers--;

--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -607,7 +607,7 @@ return declare([List, _StoreMixin], {
 			}
 
 			// Is this row's observer index different than those on either side?
-			if(thisIndex > -1 && thisIndex !== prevIndex && thisIndex !== nextIndex){
+			if(this.cleanupObservers && thisIndex > -1 && thisIndex !== prevIndex && thisIndex !== nextIndex){
 				// This is the last row that references the observer index.  Cancel the observer.
 				var observers = this.observers;
 				var observer = observers[thisIndex];

--- a/extensions/Pagination.js
+++ b/extensions/Pagination.js
@@ -24,7 +24,7 @@ function(_StoreMixin, declare, lang, Deferred, on, query, string, has, put, i18n
 			}
 			delete grid._oldPageNodes;
 			// Also remove the observer from the previous page, if there is one
-			if(grid._oldPageObserver){
+			if(this.cleanupObservers && grid._oldPageObserver){
 				grid._oldPageObserver.cancel();
 				grid._numObservers--;
 				delete grid._oldPageObserver;

--- a/tree.js
+++ b/tree.js
@@ -77,6 +77,8 @@ function tree(column){
 		var grid = column.grid,
 			colSelector = ".dgrid-content .dgrid-column-" + column.id,
 			listeners = []; // to be removed when this column is destroyed
+
+		grid.cleanupObservers = false;
 		
 		if(!grid.store){
 			throw new Error("dgrid tree column plugin requires a store to operate.");


### PR DESCRIPTION
Add a flag, defaulted to true, to set whether to cleanup the observers. This is
used by the tree plugin, which will set it to false, so that the observers are
not cleaned up when the tree plugin is used. The child quries in the tree plugin
set the _numObservers value to > 1, which ends up making the List not refresh
the observer for the main query. Changes to the the main row data in the store
would not be reflected in the grid as a result.

Fixes #713
