### PR TITLE
Improve dgrid focus event generation and tab stop handling

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -37,9 +37,8 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 				// event
 				target = target.target;
 			}
-			var element;
+			var element, row, rowElement;
 			if(target.nodeType){
-				var object;
 				do{
 					if(this._rowIdToObject[target.id]){
 						break;
@@ -54,8 +53,8 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 				}while(target && target != this.domNode);
 			}
 			if(!element && typeof columnId != "undefined"){
-				var row = this.row(target),
-					rowElement = row && row.element;
+				row = this.row(target);
+				rowElement = row && row.element;
 				if(rowElement){
 					var elements = rowElement.getElementsByTagName("td");
 					for(var i = 0; i < elements.length; i++){
@@ -79,7 +78,6 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 			// summary:
 			//		Generates the grid for each row (used by renderHeader and and renderRow)
 			var row = put("table.dgrid-row-table[role=presentation]"),
-				cellNavigation = this.cellNavigation,
 				// IE < 9 needs an explicit tbody; other browsers do not
 				tbody = (has("ie") < 9 || has("quirks")) ? put(row, "tbody") : row,
 				tr,
@@ -144,7 +142,6 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 		},
 		
 		renderRow: function(object, options){
-			var self = this;
 			var row = this.createRowCells("td", function(td, column){
 				var data = object;
 				// Support get function or field property (similar to DataGrid)
@@ -172,7 +169,6 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 			//		Setup the headers for the grid
 			var
 				grid = this,
-				columns = this.columns,
 				headerNode = this.headerNode,
 				i = headerNode.childNodes.length;
 			
@@ -205,7 +201,7 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 					th.className += " dgrid-sortable";
 				}
 			}, this.subRows && this.subRows.headerRows);
-			this._rowIdToObject[row.id = this.id + "-header"] = this.columns;
+			row.id = this.id + "-header";
 			headerNode.appendChild(row);
 			
 			// If the columns are sortable, re-sort on clicks.

--- a/List.js
+++ b/List.js
@@ -366,13 +366,13 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 			var observers = this.observers,
 				i;
 			for(i in this._rowIdToObject){
-				if(this._rowIdToObject[i] != this.columns){
-					var rowElement = byId(i);
-					if(rowElement){
-						this.removeRow(rowElement, true);
-					}
+				var rowElement = byId(i);
+				if(rowElement){
+					this.removeRow(rowElement, true);
 				}
 			}
+			this._rowIdToObject = {};
+
 			// remove any store observers
 			for(i = 0;i < observers.length; i++){
 				var observer = observers[i];
@@ -403,7 +403,6 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 			// summary:
 			//		refreshes the contents of the grid
 			this.cleanup();
-			this._rowIdToObject = {};
 			this._autoId = 0;
 			
 			// make sure all the content has been removed so it can be recreated
@@ -432,7 +431,7 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 					if(next.rowIndex > -1){
 						if(this.maintainOddEven){
 							if((next.className + ' ').indexOf("dgrid-row ") > -1){
-								put(next, '.' + (rowIndex % 2 == 1 ? oddClass : evenClass) + '!' + (rowIndex % 2 == 0 ? oddClass : evenClass));
+								put(next, '.' + (rowIndex % 2 == 1 ? oddClass : evenClass) + '!' + (rowIndex % 2 === 0 ? oddClass : evenClass));
 							}
 						}
 						next.rowIndex = rowIndex++;
@@ -521,7 +520,7 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 								// the inserted row is first, so we update firstRow to point to it
 								var previous = row.previousSibling;
 								// if we are not in sync with the previous row, roll the firstRow back one so adjustRowIndices can sync everything back up.
-								firstRow = !previous || previous.rowIndex + 1 == row.rowIndex || row.rowIndex == 0 ?
+								firstRow = !previous || previous.rowIndex + 1 == row.rowIndex || row.rowIndex === 0 ?
 									row : previous;
 							}
 						}
@@ -659,8 +658,12 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 				var object;
 				do{
 					var rowId = target.id;
-					if((object = this._rowIdToObject[rowId])){
-						return new this._Row(rowId.substring(this.id.length + 5), object, target); 
+					if (rowId){
+						if((object = this._rowIdToObject[rowId])){
+							return new this._Row(rowId.substring(this.id.length + 5), object, target);
+						}else if(rowId === (this.id + "-header")){
+							return new this._Row(rowId.substring(this.id.length + 5), object, target);
+						}
 					}
 					target = target.parentNode;
 				}while(target && target != this.domNode);
@@ -871,7 +874,7 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 						// fall back undefined values to "" for more consistent behavior
 						if(aVal === undefined){ aVal = ""; }
 						if(bVal === undefined){ bVal = ""; }
-						return aVal == bVal ? 0 : (aVal > bVal == !descending ? 1 : -1);
+						return aVal == bVal ? 0 : (aVal > bVal !== descending ? 1 : -1);
 					});
 				}
 				this.renderArray(this._lastCollection);


### PR DESCRIPTION
This update includes:
- Clicking on the same cell or row no longer causes focus out/in events to be generated.  
- Focusing on the header with cell navigation turned off works; events are generated.  
- The grid/list will now generate focus events when you use the tab key to move in or out of a grid. 
- The code also makes sure there is only one tab stop in the data rows or two total for the grid.  Before, the initial tab stops were not being removed.
- I made some changes to `List` and `Grid` to make a linter happier.
- I changed the closure for `this` from `grid` to `self` in `Keyboard`.  Using `grid` was hazardous because the tests create global variables named `grid` which caused some tests to kind of work when they shouldn't have.
- The header row is no longer placed in the row id map.  `refresh` was removing it before so putting it in the map was useless.  I updated the `row` method to located a header row based on the structure of its id.
