### PR TITLE
Fixes #734, do not set the tab index on a grid header when the header is hidden

### DIFF
--- a/Keyboard.js
+++ b/Keyboard.js
@@ -80,9 +80,16 @@ var Keyboard = declare(null, {
 				initialNode = areaNode;
 			
 			function initHeader(){
-				grid._focusedHeaderNode = initialNode =
-					cellNavigation ? grid.headerNode.getElementsByTagName("th")[0] : grid.headerNode;
-				if(initialNode){ initialNode.tabIndex = grid.tabIndex; }
+				if(grid._focusedHeaderNode){
+					// Remove the tab index for the node that previously had it.
+					grid._focusedHeaderNode.tabIndex = -1;
+				}
+				if(grid.showHeader){
+					// Set the tab index only if the header is visible.
+					grid._focusedHeaderNode = initialNode =
+						cellNavigation ? grid.headerNode.getElementsByTagName("th")[0] : grid.headerNode;
+					if(initialNode){ initialNode.tabIndex = grid.tabIndex; }
+				}
 			}
 			
 			if(isHeader){

--- a/test/intern/functional.js
+++ b/test/intern/functional.js
@@ -1,3 +1,4 @@
 define([
-	'./functional/Keyboard'
+	'./functional/Keyboard',
+	'./functional/KeyboardTab'
 ], function(){});

--- a/test/intern/functional/KeyboardTab.html
+++ b/test/intern/functional/KeyboardTab.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test Keyboard Mixin with Tab key</title>
+<style>
+	.functionalTest .dgrid {
+		height: 300px;
+		width: 400px;
+		margin: 20px;
+	}
+</style>
+</head>
+<body class="functionalTest">
+<button id="showHeaderButton" tabindex="0">Show Header</button>
+<div id="grid1"></div>
+<div id="grid2"></div>
+
+<script src="../../../../dojo/dojo.js" data-dojo-config="async: true"></script>
+<script>
+var ready;
+require([
+	"dojo/_base/declare", "dgrid/Grid", "dgrid/Keyboard", "dgrid/List", "dojo/on"
+], function(declare, Grid, Keyboard, List, on){
+	var i;
+	var data;
+	var button = document.getElementById("showHeaderButton");
+	var KeyboardGrid = declare([Grid, Keyboard]);
+	var grid1 = new KeyboardGrid({
+		showHeader: true,
+		columns: {
+			id: "ID",
+			value: "Value"
+		}
+	}, "grid1");
+	data = [];
+	for(i = 0; i < 10; i++){
+		data.push({id: i, value: "Value " + i});
+	}
+	grid1.renderArray(data);
+
+	var grid2 = new KeyboardGrid({
+		showHeader: false,
+		columns: {
+			id: "ID",
+			value: "Value"
+		}
+	}, "grid2");
+	data = [];
+	for(; i < 20; i++){
+		data.push({id: i, value: "Value " + i});
+	}
+	grid2.renderArray(data);
+	button.focus();
+
+	on(button, "click", function(){
+		grid2.set("showHeader", true);
+		button.focus();
+	});
+
+	ready = true;
+});
+</script>
+
+</body>
+</html>

--- a/test/intern/functional/KeyboardTab.js
+++ b/test/intern/functional/KeyboardTab.js
@@ -1,0 +1,78 @@
+define([
+	"intern!object",
+	"intern/chai!assert",
+	"require"
+], function(test, assert, require){
+	var tabKey = "\uE004";
+	return test({
+		before: function(){
+			// Get our html page. This page should load all necessary scripts
+			// since this functional test module runs on the server and can't load
+			// such scripts. Further, in the html page, set a global "ready" var
+			// to true to tell the runner to continue.
+			return this.get("remote")
+				.get(require.toUrl("./KeyboardTab.html"))
+				.waitForCondition("ready", 125000);
+		},
+
+		"grids with and without headers -> tab key": function(){
+			return this.get("remote")
+				.active()
+				.getAttribute("id")
+				.then(function(id){
+					assert.strictEqual(id, "showHeaderButton", "Focus is on the button: " + id);
+				})
+				.type(tabKey)
+				.active()
+				.getAttribute("role").then(function(role){
+					assert.strictEqual(role, "columnheader", "Focus is on a column header: " + role);
+				})
+				.type(tabKey)
+				.active().getAttribute("role").then(function(role){
+					assert.strictEqual(role, "gridcell", "Focus is on a grid cell: " + role);
+				})
+				.text().then(function(text){
+					assert.strictEqual(text, "0", "The cell with focus contains a 0: " + text);
+				})
+				.type(tabKey)
+				.active().getAttribute("role").then(function(role){
+					assert.strictEqual(role, "gridcell", "Focus is on a grid cell: " + role);
+				})
+				.text().then(function(text){
+					assert.strictEqual(text, "10", "The cell with focus contains an 10: " + text);
+				})
+				.reset()
+				.elementById("showHeaderButton")
+				.click()
+				.active()
+				.getAttribute("id")
+				.then(function(id){
+					assert.strictEqual(id, "showHeaderButton", "Focus is on the button: " + id);
+				})
+				.type(tabKey)
+				.active()
+				.getAttribute("role").then(function(role){
+					assert.strictEqual(role, "columnheader", "Focus is on a column header: " + role);
+				})
+				.type(tabKey)
+				.active().getAttribute("role").then(function(role){
+					assert.strictEqual(role, "gridcell", "Focus is on a grid cell: " + role);
+				})
+				.text().then(function(text){
+					assert.strictEqual(text, "0", "The cell with focus contains a 0: " + text);
+				})
+				.type(tabKey)
+				.active()
+				.getAttribute("role").then(function(role){
+					assert.strictEqual(role, "columnheader", "Focus is on a column header: " + role);
+				})
+				.type(tabKey)
+				.active().getAttribute("role").then(function(role){
+					assert.strictEqual(role, "gridcell", "Focus is on a grid cell: " + role);
+				})
+				.text().then(function(text){
+					assert.strictEqual(text, "10", "The cell with focus contains an 10: " + text);
+				});
+		}
+	});
+});


### PR DESCRIPTION
When a grid's header is hidden, do not set a tab stop in the header.  Each time `showHeader` is changed via `grid.set('showHeader', ...)`, the `initHeader` function is called.  The previous tab stop is now removed and a new one is added only it the header is visible.

This pull request will not merge cleanly with pull request https://github.com/SitePen/dgrid/pull/737 but the changes here to `Keyboard.js` can easily be applied to that pull request.
