### PR TITLE
Fix #716, Allow column className to be a function

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -75,7 +75,7 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 			}
 		},
 		
-		createRowCells: function(tag, each, subRows){
+		createRowCells: function(tag, each, subRows, object){
 			// summary:
 			//		Generates the grid for each row (used by renderHeader and and renderRow)
 			var row = put("table.dgrid-row-table[role=presentation]"),
@@ -84,7 +84,7 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 				tbody = (has("ie") < 9 || has("quirks")) ? put(row, "tbody") : row,
 				tr,
 				si, sl, i, l, // iterators
-				subRow, column, id, extraClassName, cell, innerCell, colSpan, rowSpan; // used inside loops
+				subRow, column, id, extraClasses, columnClass, cell, innerCell, colSpan, rowSpan; // used inside loops
 			
 			// Allow specification of custom/specific subRows, falling back to
 			// those defined on the instance.
@@ -98,16 +98,23 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 				if(subRow.className){
 					put(tr, "." + subRow.className);
 				}
-				
+
 				for(i = 0, l = subRow.length; i < l; i++){
 					// iterate through the columns
 					column = subRow[i];
 					id = column.id;
-					extraClassName = column.className || (column.field && "field-" + column.field);
+
+					extraClasses = [];
+					column.field && extraClasses.push(".field-" + column.field);
+					if(column.className){
+						columnClass = column.className.call ? column.className(object) : column.className;
+						columnClass && extraClasses.push("." + columnClass); 
+					}
+
 					cell = put(tag + (
 							".dgrid-cell.dgrid-cell-padding" +
 							(id ? ".dgrid-column-" + id : "") +
-							(extraClassName ? "." + extraClassName : "")
+							extraClasses.join("")
 						).replace(invalidClassChars,"-") +
 						"[role=" + (tag === "th" ? "columnheader" : "gridcell") + "]");
 					cell.columnId = id;
@@ -161,7 +168,7 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 				}else{
 					defaultRenderCell.call(column, object, data, td, options);
 				}
-			}, options && options.subRows);
+			}, options && options.subRows, object);
 			// row gets a wrapper div for a couple reasons:
 			//	1. So that one can set a fixed height on rows (heights can't be set on <table>'s AFAICT)
 			// 2. So that outline style can be set on a row when it is focused, and Safari's outline style is broken on <table>


### PR DESCRIPTION
- A column's className property may now be a function or a string. If
  it's a function, it will be called when the row cells are created and
  passed the object being rendered in that row.
- Cells will always include the dgrid-generated "field-<field name>" class, even
  if a custom class is specified.
- Changes to the value of an editor column after row cells have been
  generated can be handled via a "dgrid-datachange" listener.
