### PR TITLE
Fixes #704, removed the mousedown event listener from editor

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -209,11 +209,7 @@ function createEditor(column){
 			}
 		}
 	}
-	
-	// XXX: stop mousedown propagation to prevent confusing Keyboard mixin logic
-	// with certain widgets; perhaps revising KB's `handledEvent` would be better.
-	on(node, "mousedown", function(evt){ evt.stopPropagation(); });
-	
+
 	return cmp;
 }
 


### PR DESCRIPTION
The listener was not allowing the selectOnClick for any TextBox based widget to be effective and I could not find any problems that listener was solving.
