### PR TITLE
When creating style tag, include type="text/css"

### DIFF
--- a/util/misc.js
+++ b/util/misc.js
@@ -118,7 +118,7 @@ define(["put-selector/put"], function(put){
 			
 			if(!extraSheet){
 				// First time, create an extra stylesheet for adding rules
-				extraSheet = put(document.getElementsByTagName("head")[0], "style");
+				extraSheet = put(document.getElementsByTagName("head")[0], "style[type='text/css']");
 				// Keep reference to actual StyleSheet object (`styleSheet` for IE < 9)
 				extraSheet = extraSheet.sheet || extraSheet.styleSheet;
 				// Store name of method used to remove rules (`removeRule` for IE < 9)


### PR DESCRIPTION
When trying to create the `<style>` tag in IE9, an exception is thrown.

``` js
// First time, create an extra stylesheet for adding rules
extraSheet = put(document.getElementsByTagName("head")[0], "style");
// Keep reference to actual StyleSheet object (`styleSheet` for IE < 9)
extraSheet = extraSheet.sheet || extraSheet.styleSheet;
```

`extraSheet.sheet` throws the exception.

It looks like you need to supply `type="text/css"` when creating the tag.
