### PR TITLE
Allow functions to be used as column sorters

### DIFF
--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -152,7 +152,7 @@ function(kernel, declare, lang, Deferred, listen, aspect, put){
 			// summary:
 			//		Get a fresh queryOptions object, also including the current sort
 			var options = lang.delegate(this.queryOptions, {});
-			if(this._sort.length){
+			if(typeof(this._sort) === 'function' || this._sort.length){
 				// Prevents SimpleQueryEngine from doing unnecessary "null" sorts (which can
 				// change the ordering in browsers that don't use a stable sort algorithm, eg Chrome)
 				options.sort = this._sort;


### PR DESCRIPTION
This is just a small change to `_StoreMixin._getQueryOptions` so that it will return `this._sort` if it's a function or an array.
