### PR TITLE
Show noDataMessage whenever grid has no data.

### DIFF
--- a/List.js
+++ b/List.js
@@ -582,6 +582,10 @@ function(kernel, declare, listen, has, miscUtil, TouchScroll, hasClass, put){
 				}
 			}
 			
+			if(rows.length > 0 && this.noDataNode){
+				put(this.noDataNode, '!');
+			}
+
 			return whenDone(rows);
 		},
 

--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -87,6 +87,15 @@ function(kernel, declare, lang, Deferred, listen, aspect, put){
 				this._notifyHandle.remove();
 			}
 		},
+
+		refresh: function(){
+			this.inherited(arguments);
+			if(!this.store){
+				this.noDataNode = put(this.contentNode, "div.dgrid-no-data");
+				this.noDataNode.innerHTML = this.noDataMessage;
+			}
+			console.log('done refreshing');
+		},
 		
 		_configColumn: function(column){
 			// summary:


### PR DESCRIPTION
Fixes #765

Override `refresh` in _StoreMixin to show the message, and add a check in `renderArray` in List to remove it when data is rendered manually.
