### PR TITLE
Fix #775 transform3d test so that querySelector is used instead of document.body

### DIFF
--- a/util/has-css3.js
+++ b/util/has-css3.js
@@ -58,7 +58,7 @@ function(has){
 		// Apply csstransforms3d class to test transform-3d media queries.
 		element.className = "has-csstransforms3d";
 		// Add to body to allow measurement.
-		document.body.appendChild(element);
+		document.querySelector("body").appendChild(element);
 		left = element.offsetLeft;
 		
 		if (left === 9) {
@@ -68,7 +68,7 @@ function(has){
 			prefix = cssPrefixes[left - 10];
 			return prefix || false;
 		}
-		document.body.removeChild(element);
+		element.parentNode.removeChild(element);
 		element.className = "";
 		
 		return false; // otherwise, not supported


### PR DESCRIPTION
on iOS7 Safari document.body appeared to be null sometimes, but document.querySelector appears to not have this problem.
