### PR TITLE
Fixes #751: pass cell's value to canEdit when using a shared editor

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -368,29 +368,33 @@ function edit(cell) {
 	cellElement = cell.element.contents || cell.element;
 	
 	if((cmp = column.editorInstance)){ // shared editor (editOn used)
-		if(activeCell != cellElement &&
-				(!column.canEdit || column.canEdit(cell.row.data, value))){
-			activeCell = cellElement;
+		if(activeCell != cellElement){
+			// get the cell value
 			row = cell.row;
 			dirty = this.dirty && this.dirty[row.id];
 			value = (dirty && field in dirty) ? dirty[field] :
 				column.get ? column.get(row.data) : row.data[field];
-			
-			showEditor(column.editorInstance, column, cellElement, value);
-			
-			// focus / blur-handler-resume logic is surrounded in a setTimeout
-			// to play nice with Keyboard's dgrid-cellfocusin as an editOn event
-			dfd = new Deferred();
-			setTimeout(function(){
-				// focus the newly-placed control (supported by form widgets and HTML inputs)
-				if(cmp.focus){ cmp.focus(); }
-				// resume blur handler once editor is focused
-				if(column._editorBlurHandle){ column._editorBlurHandle.resume(); }
-				dfd.resolve(cmp);
-			}, 0);
-			
-			return dfd.promise;
+			// check to see if the cell can be edited
+			if(!column.canEdit || column.canEdit(cell.row.data, value)){
+				activeCell = cellElement;
+
+				showEditor(column.editorInstance, column, cellElement, value);
+
+				// focus / blur-handler-resume logic is surrounded in a setTimeout
+				// to play nice with Keyboard's dgrid-cellfocusin as an editOn event
+				dfd = new Deferred();
+				setTimeout(function(){
+					// focus the newly-placed control (supported by form widgets and HTML inputs)
+					if(cmp.focus){ cmp.focus(); }
+					// resume blur handler once editor is focused
+					if(column._editorBlurHandle){ column._editorBlurHandle.resume(); }
+					dfd.resolve(cmp);
+				}, 0);
+
+				return dfd.promise;
+			}
 		}
+
 	}else if(column.editor){ // editor but not shared; always-on
 		cmp = cellElement.widget || cellElement.input;
 		if(cmp){

--- a/test/intern/all.js
+++ b/test/intern/all.js
@@ -8,5 +8,6 @@ define([
 	'intern/node_modules/dojo/has!host-browser?./core/stores',
 	'intern/node_modules/dojo/has!host-browser?./core/_StoreMixin',
 	'intern/node_modules/dojo/has!host-browser?./core/OnDemand-removeRow',
-	'intern/node_modules/dojo/has!host-browser?./extensions/Pagination'
+	'intern/node_modules/dojo/has!host-browser?./extensions/Pagination',
+	'intern/node_modules/dojo/has!host-browser?./plugins/editor'
 ], function(){});

--- a/test/intern/plugins/editor.js
+++ b/test/intern/plugins/editor.js
@@ -1,0 +1,99 @@
+define([
+	"intern!tdd",
+	"intern/chai!assert",
+	"dojo/on",
+	"dijit/form/TextBox",
+	"dgrid/Grid",
+	"dgrid/editor"
+], function(test, assert, on, TextBox, Grid, editor){
+
+	var grid;
+
+	test.suite("editor plug-in", function(){
+
+		test.afterEach(function(){
+			if(grid){
+				grid.destroy();
+			}
+		});
+
+		test.test("canEdit - not shared editor", function(){
+			var results = {};
+			var data = [
+				{id: 1, data1: "Data 1.a", data2: "Data 2.a"},
+				{id: 2, data1: "Data 1.b", data2: "Data 2.b"},
+				{id: 3, data1: "Data 1.c", data2: "Data 2.c"}
+			];
+			grid = new Grid({
+				columns: [
+					{
+						field: "data1",
+						label: "Data 1"
+					},
+					editor({
+						field: "data2",
+						label: "Data 2",
+						canEdit: function(object, value){
+							results[object.id] = value;
+						}
+					})
+				]
+			});
+			document.body.appendChild(grid.domNode);
+			grid.startup();
+			grid.renderArray(data);
+
+			assert.strictEqual(results[1], "Data 2.a");
+			assert.strictEqual(results[2], "Data 2.b");
+			assert.strictEqual(results[3], "Data 2.c");
+		});
+
+		test.test("canEdit - shared editor", function(){
+			var results = {};
+			var data = [
+				{id: 1, data1: "Data 1.a", data2: "Data 2.a"},
+				{id: 2, data1: "Data 1.b", data2: "Data 2.b"},
+				{id: 3, data1: "Data 1.c", data2: "Data 2.c"}
+			];
+			grid = new Grid({
+				columns: [
+					{
+						field: "data1",
+						label: "Data 1",
+						id: "data1"
+					},
+					editor({
+						field: "data2",
+						label: "Data 2",
+						id: "data2",
+						canEdit: function(object, value){
+							results[object.id] = value;
+						}
+					}, TextBox, "click")
+				]
+			});
+			document.body.appendChild(grid.domNode);
+			grid.startup();
+			grid.renderArray(data);
+
+			assert.isUndefined(results[1]);
+			assert.isUndefined(results[2]);
+			assert.isUndefined(results[3]);
+
+			on.emit(grid.cell(1, "data2").element, "click", {});
+			assert.isUndefined(results[1]);
+			assert.strictEqual(results[2], "Data 2.b");
+			assert.isUndefined(results[3]);
+
+			on.emit(grid.cell(0, "data2").element, "click", {});
+			assert.strictEqual(results[1], "Data 2.a");
+			assert.strictEqual(results[2], "Data 2.b");
+			assert.isUndefined(results[3]);
+
+			on.emit(grid.cell(2, "data2").element, "click", {});
+			assert.strictEqual(results[1], "Data 2.a");
+			assert.strictEqual(results[2], "Data 2.b");
+			assert.strictEqual(results[3], "Data 2.c");
+		});
+	});
+});


### PR DESCRIPTION
The cell's value was being determined after `canEdit` was called.  Now the value is being retrieved first.  I also added a unit test for canEdit.
