### PR TITLE
Fixes #769: make processScroll add a loading node only when it runs a query

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -496,21 +496,23 @@ return declare([List, _StoreMixin], {
 				}
 
 				adjustHeight(preload);
+
+				// use the query associated with the preload node to get the next "page"
+				if("level" in preload.query){
+					options.queryLevel = preload.query.level;
+				}
+
+				// Avoid spurious queries (ideally this should be unnecessary...)
+				if(!("queryLevel" in options) && (options.start > grid._total || options.count < 0)){
+					continue;
+				}
+
 				// create a loading node as a placeholder while the data is loaded
 				var loadingNode = put(beforeNode, "-div.dgrid-loading[style=height:" + count * grid.rowHeight + "px]"),
 					innerNode = put(loadingNode, "div.dgrid-" + (below ? "below" : "above"));
 				innerNode.innerHTML = grid.loadingMessage;
 				loadingNode.count = count;
-				// use the query associated with the preload node to get the next "page"
-				if("level" in preload.query){
-					options.queryLevel = preload.query.level;
-				}
-				
-				// Avoid spurious queries (ideally this should be unnecessary...)
-				if(!("queryLevel" in options) && (options.start > grid._total || options.count < 0)){
-					continue;
-				}
-				
+
 				// Query now to fill in these rows.
 				// Keep _trackError-wrapped results separate, since if results is a
 				// promise, it will lose QueryResults functions when chained by `when`


### PR DESCRIPTION
This is a regression from 6160a143d9f7b9ebdfe6b80b24cb1f4aa69f3cd7.  

This problem is not specific to the `JsonRest` store but it is easy to reproduce with that store.  Here are the prerequisites to trigger this bug:
1. The grid's `loadingMessage` property needs to be set to a non-empty string.
2. `result.total` returned from the store's `query` method needs to be null or undefined.

`processScroll` in `OnDemandList` was adding a loading node but then deciding to not run a query and continue the preload processing loop.  The code that removed the loading node was not running.  Before 6160a143d9f7b9ebdfe6b80b24cb1f4aa69f3cd7, the query would run with invalid start and count values and would usually not return any results.  `processScroll` would then remove the loading node in response to the lack of query results.
