### PR TITLE
Don't throw exception for large select ranges

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -500,13 +500,17 @@ return declare(null, {
 				if(!toRow.element){
 					toRow = this.row(toRow);
 				}
-				toElement = toRow.element;
-				// find if it is earlier or later in the DOM
-				traverser = (toElement && (toElement.compareDocumentPosition ? 
-					toElement.compareDocumentPosition(element) == 2 :
-					toElement.sourceIndex > element.sourceIndex)) ? "down" : "up";
-				while(row.element != toElement && (row = this[traverser](row))){
-					this._select(row, null, value);
+				if(toRow){
+					toElement = toRow.element;
+					// find if it is earlier or later in the DOM
+					traverser = (toElement && (toElement.compareDocumentPosition ? 
+						toElement.compareDocumentPosition(element) == 2 :
+						toElement.sourceIndex > element.sourceIndex)) ? "down" : "up";
+					while(row.element != toElement && (row = this[traverser](row))){
+						this._select(row, null, value);
+					}
+				}else{
+					console.warn('select range too large')
 				}
 			}
 		}


### PR DESCRIPTION
The Selection extension can't currently handle large selection ranges because it drops nodes that are far away from the currently visible range. Emit a warning rather than throwing an exception when this happens.

Fixes #705 (or at least mitigates it for now)
