### PR TITLE
Fixes New Structure issues in test/extensions/ColumnHider

### DIFF
--- a/Keyboard.js
+++ b/Keyboard.js
@@ -237,10 +237,17 @@ var Keyboard = declare(null, {
 			}
 			newTarget = typeof focusInfo.columnId !== "undefined" ?
 				this.cell(newTarget, focusInfo.columnId) : newTarget;
+			// The focused columnId can be changed when reconfiguring columns
+			// so in these cases we can grab the cell from the first column
+			// TODO is there a more sound way to detect this case?
+			if (!newTarget.element) {
+				var firstCol = Object.keys(this.columns)[0];
+				newTarget = this.cell(newTarget, this.columns[firstCol].id);
+			}
 			if(focusInfo.active){
 				// Row/cell was previously focused, so focus the new one immediately
 				this.focus(newTarget);
-			}else{
+			}else if(newTarget.element){
 				// Row/cell was not focused, but we still need to update tabIndex
 				// and the element's class to be consistent with the old one
 				put(newTarget.element, ".dgrid-focus");


### PR DESCRIPTION
In cases where the column config changes lookup by columnId can fail, so when
this happens we just grab the first column and try again.

When there's no rows at all (e.g. Recreate Grid was called) we don't bother
trying to set focus.

I traced the breakage back to commit c632766. I wasn't exactly sure of the
best way to handle focus in these odd cases but this approach seemed decent.
