### PR TITLE
Improve the performance of a grid''s first column resize

### DIFF
--- a/extensions/ColumnResizer.js
+++ b/extensions/ColumnResizer.js
@@ -65,7 +65,7 @@ function subRowAssoc(subRows){
 	return associations;
 }
 
-function resizeColumnWidth(grid, colId, width, parentType){
+function resizeColumnWidth(grid, colId, width, parentType, noGridResize){
 	// don't react to widths <= 0, e.g. for hidden columns
 	if(width <= 0){ return; }
 
@@ -105,7 +105,9 @@ function resizeColumnWidth(grid, colId, width, parentType){
 
 		// keep a reference for future removal
 		grid._columnSizes[colId] = rule;
-		grid.resize();
+		if(!noGridResize){
+			grid.resize();
+		}
 		return true;
 	}
 }
@@ -346,7 +348,7 @@ return declare(null, {
 			// Set a baseline size for each column based on
 			// its original measure
 			colNodes.forEach(function(colNode, i){
-				this.resizeColumnWidth(colNode.columnId, colWidths[i]);
+				resizeColumnWidth(this, colNode.columnId, colWidths[i], null, true);
 			}, this);
 			
 			this._resizedColumns = true;


### PR DESCRIPTION
With ColumnResizer, when you resize a column for the first time in a grid, the grid would be resized once for each column and then again for the column you resized.  Now the grid resizes only once.
