### PR TITLE
Allow duplicates for tree top heavy test.

### DIFF
--- a/test/tree.html
+++ b/test/tree.html
@@ -133,7 +133,7 @@
 						store: testTopHeavyStore,
 						query: { parent: undefined },
 						columns: {
-							abbreviation: tree({ label: "Abbreviation", field: "abbreviation" }),
+							abbreviation: tree({ label: "Abbreviation", field: "abbreviation", allowDuplicates: true }),
 							name: "Name"
 						}
 					}, "treeTopHeavy");


### PR DESCRIPTION
It looks like this test should allow duplicates, otherwise only one instance of the shared child will ever be displayed.