### PR TITLE
Fixes #840: fixed a defect causing the second preload not to be out of place

### DIFF
--- a/List.js
+++ b/List.js
@@ -499,7 +499,7 @@ function(kernel, declare, dom, listen, has, miscUtil, TouchScroll, hasClass, put
 						// Add to new slot (either before an existing row, or at the end)
 						// First determine the DOM node that this should be placed before.
 						if(rows.length){
-							if(to < 2){ // if it is one of the first rows, we can safely get the next item
+							if(to === 0){ // if it is the first row, we can safely get the next item
 								nextNode = rows[to];
 								// Re-retrieve the element in case we are referring to an orphan
 								nextNode = nextNode && correctElement(nextNode);

--- a/test/intern/core/observable.js
+++ b/test/intern/core/observable.js
@@ -2,12 +2,13 @@ define([
 	"intern!tdd",
 	"intern/chai!assert",
 	"dojo/_base/declare",
+	"dojo/dom-class",
 	"dojo/query",
 	"dojo/store/Memory",
 	"dojo/store/Observable",
 	"dgrid/OnDemandList",
 	"put-selector/put"
-], function(test, assert, declare, query, Memory, Observable, OnDemandList, put){
+], function(test, assert, declare, domClass, query, Memory, Observable, OnDemandList, put){
 
 	var widget,
 		storeCounter = 0;
@@ -23,11 +24,15 @@ define([
 		return (index + 1) * 10;
 	}
 
+	function createItem(index){
+		var id = indexToId(index);
+		return {id: id, value: "Value " + id + " / Store " + storeCounter};
+	}
+
 	function createData(numStoreItems){
 		var data = [];
 		for(var i = 0; i < numStoreItems; i++){
-			var id = indexToId(i);
-			data.push({id: id, value: "Value " + id + " / Store " + storeCounter});
+			data.push(createItem(i));
 		}
 		return data;
 	}
@@ -104,7 +109,7 @@ define([
 
 			// Query the DOM to verify the structure matches the expected results.
 			msgPrefix = "DOM query: ";
-			query(widget.columns ? ".dgrid-content .field-value" : ".dgrid-row", widget.domNode).forEach(testRow);
+			query(".dgrid-row", widget.domNode).forEach(testRow);
 		});
 	}
 
@@ -159,6 +164,54 @@ define([
 			// Test with OnDemandList with varying overlap values
 			for(var overlap = 0; overlap <= config.itemOverlapMax; overlap++){
 				itemTestSuite("OnDemandList multiple queries", storeSize, config.itemsPerQuery, overlap, config);
+			}
+		});
+	}
+
+	function itemAddEmptyStoreTest(itemsToAddCount, itemsPerQuery, overlap){
+		var i;
+
+		function rowHasClass(rowNode, cssClass){
+			assert.isTrue(domClass.contains(rowNode, cssClass), rowNode.outerHTML + " should have " + cssClass);
+		}
+
+		test.test("Add " + itemsToAddCount + " items with " + overlap + " overlap", function(){
+			createList(0, itemsPerQuery, overlap);
+			var store = widget.store;
+			for(i = 0; i < itemsToAddCount; i++){
+				store.put(createItem(i));
+			}
+
+			var rows = query(".dgrid-content > div", widget.domNode);
+			rowHasClass(rows[0], "dgrid-preload");
+			for(i = 1; i <= itemsToAddCount; i++){
+				rowHasClass(rows[i], (i % 2) ? "dgrid-row-even" : "dgrid-row-odd");
+			}
+			rowHasClass(rows[i], "dgrid-preload");
+
+			for(i = 0; i < itemsToAddCount; i++){
+				store.put(createItem(i));
+			}
+
+			rows = query(".dgrid-content > div", widget.domNode);
+			rowHasClass(rows[0], "dgrid-preload");
+			for(i = 1; i <= itemsToAddCount; i++){
+				rowHasClass(rows[i], (i % 2) ? "dgrid-row-even" : "dgrid-row-odd");
+			}
+			rowHasClass(rows[i], "dgrid-preload");
+		});
+	}
+
+	function itemAddEmptyStoreTestSuite(config){
+		test.suite("Add items to empty store", function(){
+
+			test.afterEach(destroyWidget);
+
+			itemAddEmptyStoreTest(1, config.itemsPerQuery, 0);
+
+			// Test with OnDemandList with varying overlap values
+			for(var overlap = 0; overlap <= config.itemOverlapMax; overlap++){
+				itemAddEmptyStoreTest(config.itemsPerQuery + overlap + 1, config.itemsPerQuery, overlap);
 			}
 		});
 	}
@@ -232,5 +285,7 @@ define([
 		itemActionTestSuite("Remove store items", removeAction, config);
 		itemActionTestSuite("Insert store items before", addBeforeAction, config);
 		itemActionTestSuite("Insert store items after", addAfterAction, config);
+
+		itemAddEmptyStoreTestSuite(config);
 	});
 });


### PR DESCRIPTION
The code added recently to fix problems with `Observable` was causing new rows to be added after the preload node in the DOM.  I updated the unit tests with additional tests for adding items to empty stores.
