### PR TITLE
Fix #858: Selection: Avoid range confusion involving orphaned nodes

### DIFF
--- a/CellSelection.js
+++ b/CellSelection.js
@@ -99,10 +99,15 @@ return declare(Selection, {
 				
 				var toElement = toCell.element;
 				var fromElement = cell.element;
-				// find if it is earlier or later in the DOM
-				var traverser = (toElement && (toElement.compareDocumentPosition ? 
-					toElement.compareDocumentPosition(fromElement) == 2 :
-					toElement.sourceIndex > fromElement.sourceIndex)) ? "nextSibling" : "previousSibling";
+				// Find if it is earlier or later in the DOM
+				var direction = this._determineSelectionDirection(fromElement, toElement);
+				if(!direction){
+					// The original element was actually replaced
+					toCell = this.cell(
+						document.getElementById(toCell.row.element.id), toElement.columnId);
+					toElement = toCell && toCell.element;
+					direction = this._determineSelectionDirection(fromElement, toElement);
+				}
 				// now we determine which columns are in the range 
 				var idFrom = cell.column.id, idTo = toCell.column.id, started, columnIds = [];
 				for(id in this.columns){
@@ -132,10 +137,24 @@ return declare(Selection, {
 					if(nextNode == toElement){
 						break;
 					}
-				}while((nextNode = cell.row.element[traverser]));
+				}while((nextNode = cell.row.element[direction]));
 			}
 		}
 	},
+	
+	_determineSelectionDirection: function () {
+		// Extend Selection to return next/previousSibling instead of down/up,
+		// given how CellSelection#_select is written
+		var result = this.inherited(arguments);
+		if(result === "down"){
+			return "nextSibling";
+		}
+		if(result === "up"){
+			return "previousSibling";
+		}
+		return result;
+	},
+	
 	isSelected: function(object, columnId){
 		// summary:
 		//		Returns true if the indicated cell is selected.


### PR DESCRIPTION
If an update occurs on the row at which a selection range was started, and the user later shift+selects, an infinite loop occurs because Selection wrongly assumes that the element from the starting row is still in the document, when it was actually replaced with a new one.  This works around that by detecting if the element is no longer in the document, and grabbing the equivalent element that is in the document instead.
