### PR TITLE
Fixed tree test to detect failure case.

### DIFF
--- a/test/intern/plugins/tree.js
+++ b/test/intern/plugins/tree.js
@@ -7,12 +7,11 @@ define([
 	"dgrid/util/misc",
 	"dojo/_base/lang",
 	"dojo/_base/Deferred",
-	"dojo/aspect",
 	"dojo/on",
 	"dojo/store/Memory",
 	"dojo/store/Observable",
 	"put-selector/put"
-], function(test, assert, OnDemandGrid, tree, has, miscUtil, lang, Deferred, aspect, on, Memory, Observable, put){
+], function(test, assert, OnDemandGrid, tree, has, miscUtil, lang, Deferred, on, Memory, Observable, put){
 
 	var grid,
 		testDelay = 15,


### PR DESCRIPTION
When you revert OnDemandList to before the fix for 817, the aspect of renderArray in scrollToEnd in the tree test does not work because in that situation, the grid is not actually scrolling so renderArray is never called.  I replaced the aspect with a timer.  I also refactored the test to hopefully make it more readable.
