### PR TITLE
fix #886 ColumnHider on OSX disappeared, with latest css changes

### DIFF
--- a/List.js
+++ b/List.js
@@ -256,7 +256,7 @@ function(kernel, declare, dom, listen, has, miscUtil, TouchScroll, hasClass, put
 				bodyNode.tabIndex = -1;
 			}
 			
-			this.headerScrollNode = put(domNode, "div.dgrid-header.dgrid-header-scroll.dgrid-scrollbar-width" +
+			this.headerScrollNode = put(domNode, "div.dgrid-header-scroll.dgrid-scrollbar-width" +
 				(addUiClasses ? ".ui-widget-header" : ""));
 			
 			// Place footer node (initially hidden if showFooter is false).


### PR DESCRIPTION
We were adding the dgrid-header class to the headerScrollNode, which will hide the ColumnHider icon on OSX browsers that hide the scrollbars by default, because we set overflow:hidden in dgrid-header.

This is regression that appeared in v0.3.14, it was not present in v0.3.13.

fixes https://github.com/SitePen/dgrid/issues/886

FYI https://github.com/SitePen/dgrid/commit/eeb6eafb668d4e01de62e3d803523e8de3336b85#diff-bead9f16bff9aecbab8689853913bbcdL236
