### PR TITLE
Fix deselect publishing an event, even if it wasn't previously selected.

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -514,9 +514,13 @@ return declare(null, {
 					put(element, "!dgrid-selected!ui-state-active");
 				}
 			}
-			if(value !== previousValue && element){
+			if(element){
 				// add to the queue of row events
-				this._selectionEventQueues[(value ? "" : "de") + "select"].push(row);
+				if(!value && previousValue === true) {
+					this._selectionEventQueues.deselect.push(row);
+				} else if (value && value !== previousValue){
+					this._selectionEventQueues.select.push(row);
+				}
 			}
 			
 			if(toRow){

--- a/test/intern/plugins/selector.js
+++ b/test/intern/plugins/selector.js
@@ -31,6 +31,44 @@ define([
 		test.afterEach(function () {
 			grid.destroy();
 		});
+
+		test.test("programmatic row deselection event", function() {
+			var lastEventType;
+			var expectedEventType = "dgrid-deselect";
+			var eventCount = 0;
+			var upTo = 4;
+			grid.on("dgrid-select, dgrid-deselect", function (event) {
+				lastEventType = event.type;
+				eventCount++;
+			});
+
+			grid.select("1");
+			eventCount = 0;
+			while(upTo--) {
+				grid.deselect("1");
+			}
+			
+			assert.equal(eventCount, 1);
+			assert.equal(expectedEventType, lastEventType);
+		});
+
+		test.test("programmatic row selection event", function() {
+			var lastEventType;
+			var expectedEventType = "dgrid-select";
+			var eventCount = 0;
+			var upTo = 4;
+			grid.on("dgrid-select, dgrid-deselect", function (event) {
+				lastEventType = event.type;
+				eventCount++;
+			});
+
+			while(upTo--) {
+				grid.select("1");
+			}
+			
+			assert.equal(eventCount, 1);
+			assert.equal(expectedEventType, lastEventType);
+		});
 		
 		test.test("programmatic row selection", function () {
 			var rowNode,


### PR DESCRIPTION
Check previous value before enqueuing a deselect event.
Add tests for select and deselect events.
