### PR TITLE
fixes #886 Add ColumnHider to header node when scrollbars are hidden.

### DIFF
--- a/List.js
+++ b/List.js
@@ -40,7 +40,7 @@ function(kernel, declare, dom, listen, has, miscUtil, TouchScroll, hasClass, put
 		// position: absolute makes IE always report child's offsetLeft as 0,
 		// but it conveniently makes other browsers reset to 0 as base, and all
 		// versions of IE are known to move the scrollbar to the left side for rtl
-		isLeft = !!has("ie") || div.offsetLeft >= has("dom-scrollbar-width");
+		isLeft = (!!has("ie") || !!has("trident")) || div.offsetLeft >= has("dom-scrollbar-width");
 		cleanupTestElement(element);
 		put(div, "!");
 		element.removeAttribute("dir");

--- a/css/extensions/ColumnHider.css
+++ b/css/extensions/ColumnHider.css
@@ -8,6 +8,11 @@
 	top: 0;
 }
 
+.dgrid-rtl-swap .dgrid-hider-toggle {
+	right: auto;
+	left: 0;
+}
+
 .dgrid-hider-menu {
 	position: absolute;
 	top: 0;
@@ -19,6 +24,11 @@
 	padding: 4px;
 	overflow-x: hidden;
 	overflow-y: auto;
+}
+
+.dgrid-rtl-swap .dgrid-hider-menu {
+	right: auto;
+	left: 17px;
 }
 
 .dgrid-hider-menu-row {

--- a/extensions/ColumnHider.js
+++ b/extensions/ColumnHider.js
@@ -117,7 +117,8 @@ function(declare, has, listen, miscUtil, put, i18n){
 			var grid = this,
 				hiderMenuNode = this.hiderMenuNode,
 				hiderToggleNode = this.hiderToggleNode,
-				id;
+				id,
+				iconContainer;
 			
 			function stopPropagation(event){
 				event.stopPropagation();
@@ -128,8 +129,13 @@ function(declare, has, listen, miscUtil, put, i18n){
 			if(!hiderMenuNode){ // first run
 				// Assume that if this plugin is used, then columns are hidable.
 				// Create the toggle node.
+				if(has("dom-scrollbar-width")) {
+					iconContainer = this.headerScrollNode;
+				} else {
+					iconContainer = this.headerNode;
+				}
 				hiderToggleNode = this.hiderToggleNode =
-					put(this.headerScrollNode, "button.ui-icon.dgrid-hider-toggle[type=button]");
+					put(iconContainer, "button.ui-icon.dgrid-hider-toggle[type=button]");
 				
 				this._listeners.push(listen(hiderToggleNode, "click", function(e){
 					grid._toggleColumnHiderMenu(e);

--- a/test/data/index.json
+++ b/test/data/index.json
@@ -77,6 +77,12 @@
         "parent": "extensions"
     },
     {
+        "name": "ColumnHiderRTL.html",
+        "url": "extensions/ColumnHiderRTL.html",
+        "title": "Test Column Hider Extension RTL",
+        "parent": "extensions"
+    },
+    {
         "name": "ColumnHider_MenuHeight.html",
         "url": "extensions/ColumnHider_MenuHeight.html",
         "title": "Test Column Hider Extension: Large Menu",

--- a/test/extensions/ColumnHiderRTL.html
+++ b/test/extensions/ColumnHiderRTL.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" dir="rtl">
+	<head>
+		<meta charset="utf-8">
+		<title>Test RTL Column Hider Extension</title>
+		<meta name="viewport" content="width=570">
+		<style>
+			@import "../../../dojo/resources/dojo.css";
+			@import "../../css/skins/claro.css";
+			.dgrid {
+				width: 750px;
+				margin: 10px;
+			}
+			.field-col1 {
+				width: 100px;
+			}
+			.field-col2 {
+				width: 100px;
+			}
+			.field-col3 {
+				width: auto;
+			}
+			.field-col4 {
+				width: 100px;
+			}
+			.field-col5 {
+				width: 150px;
+			}
+		</style>
+		<script src="../../../dojo/dojo.js"
+			data-dojo-config="async: true"></script>
+		<script>
+			// Functions defined within require callback
+			var getColumns, getAltColumns, createGrid, destroyGrid;
+			
+			require(["dojo/_base/lang", "dojo/_base/declare",
+				"dgrid/OnDemandGrid", "dgrid/Keyboard", "dgrid/Selection",
+				"dgrid/extensions/ColumnHider", "dgrid/extensions/ColumnResizer", "dgrid/extensions/ColumnReorder",
+				"put-selector/put", "dgrid/test/data/base", "dojo/domReady!", "xstyle/css!../../css/dgrid_rtl.css"],
+			function(lang, declare, Grid, Keyboard, Selection, ColumnHider, ColumnResizer, ColumnReorder, put, testStore){
+				var columns = {
+						col1: "Column 1Column1Column 1 Column 1",
+						col2: { label: "Column2 (unhidable)", sortable: false, unhidable: true },
+						col3: {
+							label: "Column3 (initially hidden)",
+							hidden: true
+						},
+						col4: "Column 4",
+						col5: "Column 5"
+					},
+					altColumns = [
+						{ field: "col2", label: "Col2" },
+						// test setting unhidable *and* hidden (i.e. not in menu, not displayed)
+						{ field: "col4", label: "Col4", sortable: false, hidden: true, unhidable: true },
+						{ field: "col1", label: "Col1" },
+						{ field: "col5" } // no label, to test fallback to field
+					],
+					grid,
+					gridResize,
+					gridReorder;
+				
+				getColumns = function(){
+					return lang.clone(columns);
+				};
+				
+				getAltColumns = function(){
+					return lang.clone(altColumns);
+				};
+				
+				createGrid = function(){
+					if(grid){
+						var next = grid.domNode.nextSibling;
+						grid.destroy();
+						document.body.insertBefore(put("div#grid"), next);
+					}
+					grid = window.grid = new (declare([Grid, Keyboard, Selection, ColumnHider]))({
+						sort: "id",
+						store: testStore,
+						columns: getColumns()
+					}, "grid");
+					
+					grid.on("dgrid-columnstatechange", function(evt){
+						console.log("Column for field " + evt.column.field + " is now " +
+							(evt.hidden ? "hidden" : "shown"));
+					});
+				};
+				
+				createGrid();
+				
+				gridResize = window.gridResize = new (declare([Grid, Selection, ColumnHider, ColumnResizer]))({
+					sort: "id",
+					store: testStore,
+					columns: lang.clone(columns)
+				}, "gridresize");
+				gridReorder = window.gridReorder = new (declare([Grid, Selection, ColumnReorder, ColumnHider]))({
+					sort: "id",
+					store: testStore,
+					columns: lang.clone(columns)
+				}, "gridreorder");
+			});
+		</script>
+	</head>
+	<body class="claro">
+		<h2>A basic grid with the column hider plugin</h2>
+		<div id="grid"></div>
+		<div>Buttons to test changing column structure and recreating grid:
+			<button onclick="grid.set('columns', getColumns());">Original Structure</button>
+			<button onclick="grid.set('columns', getAltColumns());">New Structure</button>
+			<button onclick="createGrid();">Recreate Grid</button>
+		</div>
+		<h2>Another grid w/ ColumnHider and ColumnResizer</h2>
+		<div id="gridresize"></div>
+		<h2>Another grid w/ ColumnHider and ColumnReorder</h2>
+		<div id="gridreorder"></div>
+	</body>
+</html>


### PR DESCRIPTION
When the scrollbars are hidden on OSX we want to add the ColumnHiderIcon node as a child of the header node. On a platform that has scrollbars we want to add the ColumnHiderIcon as a child of the headerScrollNode.

Also fixed a small IE11 bug which was causing us to fail to add the dgrid-rtl-swap class to the table. This would result in a small rendering bug for positioning the headerScrollNode properly.

Finally I added a test page for the column hider extension running on a RTL page.

Replaces https://github.com/SitePen/dgrid/pull/888
Fixes https://github.com/SitePen/dgrid/issues/886
