### PR TITLE
Emit dgrid-page-loaded when page finishes loading

### DIFF
--- a/extensions/Pagination.js
+++ b/extensions/Pagination.js
@@ -469,6 +469,14 @@ function(_StoreMixin, declare, arrayUtil, lang, Deferred, on, query, string, has
 						// It's especially important that _updateNavigation is called only
 						// after renderArray is resolved as well (to prevent jumping).
 						grid._updateNavigation(focusLink);
+						
+						setTimeout(function () {
+                            on.emit(grid.domNode, "dgrid-page-loaded", {
+                                bubbles: true,
+                                cancelable: false,
+                                grid: grid
+                            });
+                        }, 0);
 					});
 					
 					if (has("ie") < 7 || (has("ie") && has("quirks"))) {


### PR DESCRIPTION
I needed a way to know that a page finished loading so that I can do some actions after.

More specifically, when using the dgrid as in http://dojofoundation.org/packages/dgrid/demos/multiview/ (with rows that expand an present some additional content) combined with Pagination extension, if I want to    keep(or "remeber") the expand state or rows between pages navigation then I need way to know the page finished loading (equivalent with dgrid-refresh-completed).

The code is copied from the refresh() function in the same file, I just removed the "results: ..." .
I'm not sure what's best: to emit a new event like I did or to emit the same dgrid-refresh-complete.
