### PR TITLE
Keyboard._restoreFocus() clears the active selection in 'extended' mode

### DIFF
--- a/Keyboard.js
+++ b/Keyboard.js
@@ -221,6 +221,7 @@ var Keyboard = declare(null, {
 		//		previously removed row, or to the nearest sibling otherwise.
 		
 		var focusInfo = this._removedFocus,
+			oldTarget = this.row(focusInfo.rowId),
 			newTarget,
 			cell;
 		
@@ -242,10 +243,11 @@ var Keyboard = declare(null, {
 				if(cell && cell.element){
 					newTarget = cell;
 				}
+				oldTarget = this.cell(focusInfo.rowId, focusInfo.columnId);
 			}
 			if(focusInfo.active && newTarget.element.offsetHeight !== 0){
 				// Row/cell was previously focused and is visible, so focus the new one immediately
-				this.focus(newTarget);
+				this._focusOnNode(newTarget, false, { oldTarget: oldTarget.element });
 			}else{
 				// Row/cell was not focused or is not visible, but we still need to update tabIndex
 				// and the element's class to be consistent with the old one

--- a/Selection.js
+++ b/Selection.js
@@ -278,10 +278,13 @@ return declare(null, {
 		//		except that clicks/keystrokes without modifier keys will clear
 		//		the previous selection.
 		
-		// Clear selection first for right-clicks outside selection and non-ctrl-clicks;
-		// otherwise, extended mode logic is identical to multiple mode
+		// Clear selection first for right-clicks outside selection and non-ctrl-clicks.
+		// For dgrid-cellfocusin events, do not clear the selection if our target is not
+		// changing, thus preserving the selection when the target receives a store update.
+		// Otherwise, extended mode logic is identical to multiple mode.
 		if(event.button === 2 ? !this.isSelected(target) :
-				!(event.keyCode ? event.ctrlKey : event[ctrlEquiv])){
+				!(event.keyCode ? event.ctrlKey : event[ctrlEquiv]) &&
+				!(event.oldTarget && event.oldTarget === target)){
 			this.clearSelection(null, true);
 		}
 		this._multipleSelectionHandler(event, target);


### PR DESCRIPTION
If the focused row/cell receives an update from the store, the existing selection will be cleared during the focus restoration process. This only affects the 'extended' selection mode.

This is easily reproducible in the `dgrid/test/Selection.html` page.
1. Load the page and scroll down to the second grid titled **A grid with cell-level selection (default selection mode of "extended")**.
2. Hold SHIFT and make a selection from Row5,Col1 to Row0,Col1 (the first 5 vertical cells in the first column). You now have Row0,Col1 focused as it was the last one you clicked.
3. Open the console and run `gridCellNavigation.store.put(gridCellNavigation.store.get(1))`. The selection remains intact.
4. Now run `gridCellNavigation.store.put(gridCellNavigation.store.get(0))`. The selection is cleared and only Row0,Col1 remains selected.

When `Keyboard._restoreFocus()` runs, it fires the `dgrid-cellfocusin` event. `Selection._extendedSelectionHandler()` picks this up and clears the active selection.
