### PR TITLE
DnD: Update dojo/dnd UI when an item is deselected programmatically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ This document outlines changes since 0.3.0.  For older changelogs, see the
 
 * Fixed a regression in `ColumnHider` where the node to open the menu became
   invisible on platforms with hidden scrollbars. (#886)
+* Resolved an issue regarding `dojo/dnd` CSS classes and programmatic dgrid
+  deselection. (#906)
 * `ColumnHider` now assigns its menu node an ID in the format
   `{id}-hider-menu`, not `dgrid-hider-menu-{id}`.
 

--- a/extensions/DnD.js
+++ b/extensions/DnD.js
@@ -245,6 +245,9 @@ define([
 			}
 			function deselectRow(row){
 				delete selectedNodes[row.id];
+				// Re-sync dojo/dnd UI classes based on deselection
+				// (unfortunately there is no good programmatic hook for this)
+				put(row.element, '!dojoDndItemSelected!dojoDndItemAnchor');
 			}
 			
 			this.on("dgrid-select", function(event){


### PR DESCRIPTION
Fixes a bug evidenced in SO question http://stackoverflow.com/q/23254490/237950, wherein programmatically deselecting via `dgrid/Selection` leaves the classes added by `dojo/dnd` on the deselected row.
