### PR TITLE
Fix: enable Selection#selectAll method to work with non-store-backed grid

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -613,7 +613,7 @@ return declare(null, {
 		this.allSelected = true;
 		this.selection = {}; // we do this to clear out pages from previous sorts
 		for(var i in this._rowIdToObject){
-			var row = this.row(this._rowIdToObject[i]);
+			var row = this._rowIdToObject[i];
 			this._select(row.id, null, true);
 		}
 		this._fireSelectionEvents();


### PR DESCRIPTION
`dgrid/Selection`'s `selectAll` method calls `List#row` (for reasons I am not aware of - hopefully unimportant, or my fix may not be appropriate) and passes it an object, which causes the `row` method to assume the grid has a store. This causes the `selectAll` method to throw an error when used with a grid that does not use a store.
