### PR TITLE
fixes #786 Shift + row select highlights outside text (ie)

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -65,7 +65,15 @@ function setSelectable(grid, selectable){
 	var node = grid.bodyNode,
 		value = selectable ? "text" : has("ff") < 21 ? "-moz-none" : "none";
 	
-	if(hasUserSelect){
+	// IE > 9: user-select: none;
+	// When using a modifier key, IE will select text inside of the element as well
+	// as text outside of the element. This is because IE thinks the selection
+	// starts outside of the element when using a modifier.
+	//
+	// ms-user-select: none; 
+	//   will block selection from starting on that element. It will not block an
+	//   existing selection from entering the element.
+	if(hasUserSelect && hasUserSelect !== "msUserSelect"){
 		node.style[hasUserSelect] = value;
 	}else if(has("dom-selectstart")){
 		// For browsers that don't support user-select but support selectstart (IE<10),


### PR DESCRIPTION
`ms-user-select: none;` will block selection from starting on the element.
It will not block an existing selection from entering the element. [reference](http://ie.microsoft.com/TestDrive/HTML5/msUserSelect/Default.html)

When using the shift modifier IE will select everything from the top of
the document, or last clicked location, up until the shift-clicked
location. Since the selection starts outside of the element marked with
ms-user-select: none; all of the text is selected.

Added a check for `msUserSelect`, and fallback to other methods to stop
selection.

fixes: https://github.com/SitePen/dgrid/issues/786
