### PR TITLE
fixes #901 CompoundColumns with sort property causes an error

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -358,7 +358,7 @@ function(kernel, declare, listen, has, put, List, miscUtil){
 				}
 			}
 			// skip this logic if field being sorted isn't actually displayed
-			if(target){
+			if(target && (target.contents || target.children.length)){
 				target = target.contents || target;
 				// place sort arrow under clicked node, and add up/down sort class
 				this._lastSortedArrow = put(target.firstChild, "-div.dgrid-sort-arrow.ui-icon[role=presentation]");

--- a/test/intern/extensions/CompoundColumns.js
+++ b/test/intern/extensions/CompoundColumns.js
@@ -18,8 +18,9 @@ define([
 		data.push(item);
 	}
 
-	function createGrid(columns, hideHeader){
+	function createGrid(columns, hideHeader, sort){
 		grid = new CompoundColumnGrid({
+			sort: sort,
 			columns: columns,
 			showHeader: !hideHeader
 		});
@@ -29,6 +30,32 @@ define([
 	}
 
 	test.suite("CompoundColumns", function(){
+
+		test.suite("sort method", function(){
+			test.afterEach(function(){
+				grid.destroy();
+			});
+			
+			test.test("sort grid by field with hidden header", function(){
+				createGrid({
+					data0: "Data 0",
+					data1: "Data 1",
+					data2: "Data 2",
+					data3: "Data 3",
+					data4: "Data 4"
+				}, true, 'data0');
+
+				assert.strictEqual(grid.cell(0, 0).element.innerHTML, "Value 0:0");
+				assert.strictEqual(grid.cell(0, 4).element.innerHTML, "Value 0:4");
+				assert.strictEqual(grid.cell(11, 0).element.innerHTML, "Value 11:0");
+				assert.strictEqual(grid.cell(11, 4).element.innerHTML, "Value 11:4");
+				assert.isUndefined(grid.cell(0, 5).element);
+				assert.isUndefined(grid.cell(12, 0).element);
+
+			});
+		
+		});
+
 		test.suite("cell method", function(){
 			test.afterEach(function(){
 				grid.destroy();


### PR DESCRIPTION
Make sure that the target has contents or children before placing sort
arrow UI.

When trying to set the column sort arrow UI on a hidden column header we
were making the assumption that the column header had children. But if
the header was hidden it would cause an exception when trying to place
the UI element.

fixes https://github.com/SitePen/dgrid/issues/901
