### PR TITLE
Restore the dgrid-highlight class when highlighting rows

### DIFF
--- a/List.js
+++ b/List.js
@@ -411,7 +411,7 @@ function(declare, listen, has, miscUtil, hasClass, put){
 			//		ui-state-highlight class.
 			
 			rowElement = rowElement.element || rowElement;
-			put(rowElement, ".ui-state-highlight" +
+			put(rowElement, ".dgrid-highlight" +
 				(this.addUiClasses ? ".ui-state-highlight" : ""));
 			setTimeout(function(){
 				put(rowElement, "!dgrid-highlight!ui-state-highlight");


### PR DESCRIPTION
The dgrid-highlight class had somehow been removed in commit/merge dd037af9df987dc549980cd42b6d9edf77c57ea4, so just restoring this.
