### PR TITLE
Fixing performance issue in multiview gallery for rendering large data sets

### DIFF
--- a/demos/multiview/resources/multiview.css
+++ b/demos/multiview/resources/multiview.css
@@ -73,8 +73,8 @@
 /* styles for gallery view */
 
 .gallery .dgrid-row {
-    width: 25%;
-    display: inline-block;
+	width: 25%;
+	display: inline-block;
 	text-align: center;
 	padding: 1em 0;
 }


### PR DESCRIPTION
Updated the multiview gallery example's css to use display:inline-block; rather than float: left for positioning grid items.  As reported in #882 when a large dataset is used the browser starts to behave unpredictable due to a performance differences.

I couldn't reproduce the issue described in #882.  But when using float to render a data set of 8000 items it took almost a minute on Chrome.  Display: inline-block rendered instantly by comparison.
