### PR TITLE
Fixes issue with dragging to end of grid

### DIFF
--- a/extensions/DnD.js
+++ b/extensions/DnD.js
@@ -90,7 +90,7 @@ define([
 			// directly on self doesn't fire onDrop, but we do have to worry about
 			// dropping last node into empty space beyond rendered rows.)
 			if(!copy && (targetRow === nodes[0] ||
-					(!targetItem && grid.down(grid.row(nodes[0])).element == nodes[0]))){
+					(!targetItem && nodes[0].parentNode && anchor && grid.down(grid.row(nodes[0])).element == nodes[0]))){
 				return;
 			}
 			


### PR DESCRIPTION
If dragging a row to the end of the grid immediately after dragging and
dropping the same row the node provided will be the drop handle, and
will result in an early return.

This commit bypasses the early return when the node provided is a drop handle
(detached from the grid) rather than an actual row.
