### PR TITLE
Better support of radio button widget

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -122,7 +122,7 @@ function setPropertyFromEditor(grid, cmp, triggerEvent) {
 		}
 
 		if(cmp.type === "radio" && cmp.name && !column.editOn && column.field){
-			editedRow = grid.row(cmp);
+			editedRow = grid.row(cmp.domNode || cmp);
 			
 			// Update all other rendered radio buttons in the group
 			query("input[type=radio][name=" + cmp.name + "]", grid.contentNode).forEach(function(radioBtn){


### PR DESCRIPTION
When editor (cmp in the code) is a dijit/form/RadioButton widget, grid.row(cmp) returns incorrect row object, because row() function cannot determine row by dijit widget.

This way editedRow variable has incorrect row object and code in the lines 144-148 resets radio button value.