### PR TITLE
clear selection event queue before emitting event

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -456,10 +456,10 @@ return declare(null, {
 		}
 		eventObject[this._selectionTargetType] = queue;
 		
-		on.emit(this.contentNode, "dgrid-" + type, eventObject);
-		
 		// Clear the queue so that the next round of (de)selections starts anew
 		this._selectionEventQueues[type] = [];
+		
+		on.emit(this.contentNode, "dgrid-" + type, eventObject);
 	},
 	
 	_fireSelectionEvents: function(){


### PR DESCRIPTION
Clear the event queue before the selection event is fired to prevent
recursing if an event handler also triggers a selection event. For example, if a callback were to call `clearSelection`, this will deselect the rows and then call `_fireSelectionEvents`, which will emit the same selection event again and again.

``` javascript
require([
    'dojo/_base/declare',
    'dgrid/List',
    'dgrid/Selection'
], function (declare, List, Selection) {
    var data = [ 'joe', 'bob', 'jim' ],
        list = new declare([List, Selection])({}, 'main');

    list.renderArray(data);

    list.on('dgrid-select', function (event) {
        console.log('select', event.rows[0].data);
        // clear selection will cause the selection events to be fired, 
        // including the event that triggered this callback
        list.clearSelection();
    });
});
```
