### PR TITLE
Delay starting the column grid until the feature editor is completely started

### DIFF
--- a/demos/laboratory/widgets/FeatureEditor.js
+++ b/demos/laboratory/widgets/FeatureEditor.js
@@ -3,13 +3,14 @@ define([
 	'dojo/_base/array',
 	'dojo/_base/declare',
 	'dojo/_base/lang',
+	'dojo/Deferred',
 	'dojo/topic',
 	'dstore/Memory',
 	'dstore/Trackable',
 	'dijit/layout/StackContainer',
 	'./FeatureGrid',
 	'../data/features'
-], function (require, arrayUtil, declare, lang, topic, Memory, Trackable, StackContainer, FeatureGrid,
+], function (require, arrayUtil, declare, lang, Deferred, topic, Memory, Trackable, StackContainer, FeatureGrid,
 		featureData) {
 
 	return declare(StackContainer, {
@@ -18,9 +19,6 @@ define([
 
 		buildRendering: function () {
 			this.inherited(arguments);
-
-			var self = this;
-			var configModuleIds = [];
 
 			this.configPanes = {};
 
@@ -33,7 +31,23 @@ define([
 				featureType: 'grid'
 			});
 			this.addChild(this.featureGrid);
+		},
 
+		postCreate: function () {
+			this.inherited(arguments);
+
+			this.own(
+				this.featureGrid.on('configure-module', lang.hitch(this, '_showModuleConfig')),
+				this.store.on('add,delete,update', lang.hitch(this, '_onUpdateStore'))
+			);
+		},
+
+		startup: function () {
+			this.inherited(arguments);
+
+			var self = this;
+			var configModuleIds = [];
+			var dfd = new Deferred();
 			arrayUtil.forEach(featureData, function (feature) {
 				if (feature.configModule) {
 					configModuleIds.push('./' + feature.configModule);
@@ -60,16 +74,10 @@ define([
 						this.configPanes[feature.mid] = configPane;
 					}
 				}, self);
+				dfd.resolve();
 			});
-		},
 
-		postCreate: function () {
-			this.inherited(arguments);
-
-			this.own(
-				this.featureGrid.on('configure-module', lang.hitch(this, '_showModuleConfig')),
-				this.store.on('add,delete,update', lang.hitch(this, '_onUpdateStore'))
-			);
+			return dfd.promise;
 		},
 
 		isSelected: function (moduleId) {

--- a/demos/laboratory/widgets/Laboratory.js
+++ b/demos/laboratory/widgets/Laboratory.js
@@ -68,12 +68,13 @@ define([
 			var columnEditor = this.columnEditor;
 			this.inherited(arguments);
 
-			this.featureEditor.startup();
-			columnEditor.startup();
+			this.featureEditor.startup().then(function () {
+				columnEditor.startup();
 
-			// Add a couple of columns by default
-			columnEditor.addColumn('First Name');
-			columnEditor.addColumn('Last Name');
+				// Add a couple of columns by default
+				columnEditor.addColumn('First Name');
+				columnEditor.addColumn('Last Name');
+			});
 		},
 
 		selectTab: function (evt) {
@@ -167,7 +168,7 @@ define([
 				storeModules = [ 'Memory', 'Trackable' ];
 
 				if (treeExpandoColumn) {
-						storeModules.push('TreeStoreMixin');
+					storeModules.push('TreeStoreMixin');
 				}
 
 				gridConfig.dataDeclaration = 'var store = new (declare([' + storeModules.join(', ') + ']))({\n' +


### PR DESCRIPTION
When laboratory would start and the user enabled the Tree mixin, the "First Name" column definition would not have `renderExpando: true` applied to it.  Adding a new column would cause everything to work. 

`laboratory/widgets/configForms/Tree` subscribes to the `/store/columns/update` topic and tracks the available columns.  The problem was the tree config-form was being loaded after the initial columns were added to the `ColumnGrid` and so it had not yet subscribed to `/store/columns/update` when the "First Name" and "Last Name" column definitions where added.

I modified `FeatureEditor` so the feature config file is now loaded in startup.  Because the config-form modules are loaded asynchronously, I made `FeatureEditor#startup` return a promise.  Now `Laboratory` does not start the `ColumnGrid` or add the initial column definitions until the `FeatureEditor#startup` promise is resolved.