### PR TITLE
Removed typo in the migration guide

### DIFF
--- a/doc/migrating/0.4-Migration.md
+++ b/doc/migrating/0.4-Migration.md
@@ -219,11 +219,11 @@ require([
 				label: 'Age'
 			},
 			// This field always shows a text input:
-			editor({
+			{
 				field: 'income',
 				label: 'Income',
 				editor: 'text'
-			})
+			}
 		]
 	}, 'grid');
 }


### PR DESCRIPTION
One of the column definitions was still being wrapped by a call to the old editor plugin.