### PR TITLE
fix dgrid horizontal scroll on focus

### DIFF
--- a/Keyboard.js
+++ b/Keyboard.js
@@ -159,6 +159,7 @@ var Keyboard = declare(null, {
 		enableNavigation(this.contentNode);
 		
 		this._debouncedEnsureRowScroll = miscUtil.debounce(this._ensureRowScroll, this);
+		this._debouncedEnsureColumnScroll = miscUtil.debounce(this._ensureColumnScroll, this);
 	},
 	
 	removeRow: function(rowElement){
@@ -294,6 +295,19 @@ var Keyboard = declare(null, {
 			this.scrollTo({ y: rowElement.offsetTop - this.contentNode.offsetHeight + rowElement.offsetHeight });
 		}
 	},
+
+	_ensureColumnScroll: function (cellElement) {
+		// summary:
+		//		Ensures that the entire cell is visible in the viewport, such as when
+		//		the grid has a horizontal scroll
+		var scrollX = this.getScrollPosition().x;
+		if (scrollX > cellElement.offsetLeft) {
+			this.scrollTo({ x: cellElement.offsetLeft });
+		}
+		else if (scrollX + this.contentNode.offsetWidth <= cellElement.offsetLeft + cellElement.offsetWidth + cellElement.clientLeft) {
+			this.scrollTo({ x: cellElement.offsetLeft + this.contentNode.offsetWidth + cellElement.offsetWidth });
+		}
+	},
 	
 	_focusOnNode: function(element, isHeader, event){
 		var focusedNodeProperty = "_focused" + (isHeader ? "Header" : "") + "Node",
@@ -384,6 +398,8 @@ var Keyboard = declare(null, {
 		if(this.cellNavigation && (this.columnSets || this.subRows.length > 1) && !isHeader){
 			this._debouncedEnsureRowScroll(cell.row.element);
 		}
+
+		this._debouncedEnsureColumnScroll(cell.element);
 	},
 	
 	focusHeader: function(element){


### PR DESCRIPTION
When navigating with keyboard on a grid that is not wide enough to fit
the entire grid, ensure that the column is scrolled in to view in
entirety. Fixes issue in Chrome, Firefox, and Safari.

This issue can be seen in [this fiddle](http://jsfiddle.net/nicknisi/ztuqcL9v/). Navigating with the keyboard, the rightmost column does not scroll all the way in to view in Chrome, Firefox, or Safari. It does in IE10/11.