### PR TITLE
Allow properly scrolling when grid has autoheight and Rest collection

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -367,19 +367,21 @@ define([
 			if (this._hasAutoHeight()){
 				var parentNode=this.params.parentNode||window;
 
-				var cumulativeOffset = function(element) {
+				var cumulativeOffset = function(element,parent) {
     					var top = 0, left = 0;
     					do {
         					top += element.offsetTop  || 0;
         					left += element.offsetLeft || 0;
         					element = element.offsetParent;
+        					if (element == parent)
+        						break;
     					} while(element);
 					return {
         					top: top,
         					left: left
     					};
 				};
-				visibleTop=Math.max(0,parentNode.scrollY-cumulativeOffset(scrollNode).top);
+				visibleTop=Math.max(0,parentNode.scrollY-cumulativeOffset(scrollNode,parentNode).top);
 				visibleBottom=parentNode.innerHeight+visibleTop;
 			}
 			// XXX: I do not know why this happens.

--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -76,13 +76,14 @@ define([
 			// check visibility on scroll events
 			this._scrollEvent();
 		},
+
 		destroy: function () {
 			this.inherited(arguments);
 			if (this._refreshTimeout) {
 				clearTimeout(this._refreshTimeout);
 			}
- 		},
- 
+		},
+
 		renderQuery: function (query, options) {
 			// summary:
 			//		Creates a preload node for rendering a query into, and executes the query
@@ -366,19 +367,18 @@ define([
 			if (this._hasAutoHeight()){
 				var parentNode=this.params.parentNode||window;
 
-var cumulativeOffset = function(element) {
-    var top = 0, left = 0;
-    do {
-        top += element.offsetTop  || 0;
-        left += element.offsetLeft || 0;
-        element = element.offsetParent;
-    } while(element);
-
-    return {
-        top: top,
-        left: left
-    };
-};
+				var cumulativeOffset = function(element) {
+    					var top = 0, left = 0;
+    					do {
+        					top += element.offsetTop  || 0;
+        					left += element.offsetLeft || 0;
+        					element = element.offsetParent;
+    					} while(element);
+					return {
+        					top: top,
+        					left: left
+    					};
+				};
 				visibleTop=Math.max(0,parentNode.scrollY-cumulativeOffset(scrollNode).top);
 				visibleBottom=parentNode.innerHeight+visibleTop;
 			}

--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -76,7 +76,13 @@ define([
 			// check visibility on scroll events
 			this._scrollEvent();
 		},
-
+		destroy: function () {
+			this.inherited(arguments);
+			if (this._refreshTimeout) {
+				clearTimeout(this._refreshTimeout);
+			}
+ 		},
+ 
 		renderQuery: function (query, options) {
 			// summary:
 			//		Creates a preload node for rendering a query into, and executes the query
@@ -164,7 +170,7 @@ define([
 							self._total = total;
 						}
 						// now we need to adjust the height and total count based on the first result set
-						if (total === 0) {
+						if (total === 0 && parentNode) {
 							if (noDataNode) {
 								put(noDataNode, '!');
 								delete self.noDataNode;
@@ -247,12 +253,13 @@ define([
 				}).then(function () {
 					// Emit on a separate turn to enable event to be used consistently for
 					// initial render, regardless of whether the backing store is async
-					setTimeout(function () {
+					self._refreshTimeout = setTimeout(function () {
 						on.emit(self.domNode, 'dgrid-refresh-complete', {
 							bubbles: true,
 							cancelable: false,
 							grid: self
 						});
+						self._refreshTimeout = null;
 					}, 0);
 				});
 			}

--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -72,7 +72,6 @@ define([
 
 		postCreate: function () {
 			this.inherited(arguments);
-			var self = this;
 			// check visibility on scroll events
 			this._scrollEvent();
 		},
@@ -325,24 +324,24 @@ define([
 		},
 
 		lastScrollTop: 0,
-		_hasAutoHeight:function(){
-		  return this._class&&this._class.indexOf('dgrid-autoheight')>=0;
+		_hasAutoHeight: function () {
+		  return this._class && this._class.indexOf('dgrid-autoheight') >= 0;
 		},
-		_setClass:function(){
-			var before=this._hasAutoHeight();
+		_setClass: function () {
+			var before = this._hasAutoHeight();
 			this.inherited(arguments);
-			if (before!==this._hasAutoHeight()) //relink event
+			if (before !== this._hasAutoHeight()) //relink event
 				this._scrollEvent();
 		},
-		_scrollSignal:undefined,
-		_scrollEvent:function(){
-			var self=this;
+		_scrollSignal: undefined,
+		_scrollEvent: function () {
+			var self = this;
 			if (this._scrollSignal)
 			  this._scrollSignal.remove();
-			var node=this.bodyNode;
+			var node = this.bodyNode;
 			if (this._hasAutoHeight())
-			  node=this.params.parentNode||window;
-			this._scrollSignal=on(node, 'scroll',
+			  node = this.params.parentNode || window;
+			this._scrollSignal = on(node, 'scroll',
 				miscUtil[this.pagingMethod](function (event) {
 					self._processScroll(event);
 				}, null, this.pagingDelay)
@@ -364,9 +363,9 @@ define([
 				// References related to emitting dgrid-refresh-complete if applicable
 				lastRows,
 				preloadSearchNext = true;
+				
 			if (this._hasAutoHeight()){
-				var parentNode=this.params.parentNode||window;
-
+				var parentNode = this.params.parentNode||window;
 				var cumulativeOffset = function(element,parent) {
     					var top = 0, left = 0;
     					do {
@@ -381,8 +380,8 @@ define([
         					left: left
     					};
 				};
-				visibleTop=Math.max(0,parentNode.scrollY-cumulativeOffset(scrollNode,parentNode).top);
-				visibleBottom=parentNode.innerHeight+visibleTop;
+				visibleTop = Math.max(0,parentNode.scrollY - cumulativeOffset(scrollNode,parentNode).top);
+				visibleBottom = parentNode.innerHeight + visibleTop;
 			}
 			// XXX: I do not know why this happens.
 			// munging the actual location of the viewport relative to the preload node by a few pixels in either

--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -74,18 +74,7 @@ define([
 			this.inherited(arguments);
 			var self = this;
 			// check visibility on scroll events
-			on(this.bodyNode, 'scroll',
-				miscUtil[this.pagingMethod](function (event) {
-					self._processScroll(event);
-				}, null, this.pagingDelay)
-			);
-		},
-
-		destroy: function () {
-			this.inherited(arguments);
-			if (this._refreshTimeout) {
-				clearTimeout(this._refreshTimeout);
-			}
+			this._scrollEvent();
 		},
 
 		renderQuery: function (query, options) {
@@ -175,7 +164,7 @@ define([
 							self._total = total;
 						}
 						// now we need to adjust the height and total count based on the first result set
-						if (total === 0 && parentNode) {
+						if (total === 0) {
 							if (noDataNode) {
 								put(noDataNode, '!');
 								delete self.noDataNode;
@@ -258,13 +247,12 @@ define([
 				}).then(function () {
 					// Emit on a separate turn to enable event to be used consistently for
 					// initial render, regardless of whether the backing store is async
-					self._refreshTimeout = setTimeout(function () {
+					setTimeout(function () {
 						on.emit(self.domNode, 'dgrid-refresh-complete', {
 							bubbles: true,
 							cancelable: false,
 							grid: self
 						});
-						self._refreshTimeout = null;
 					}, 0);
 				});
 			}
@@ -329,6 +317,29 @@ define([
 		},
 
 		lastScrollTop: 0,
+		_hasAutoHeight:function(){
+		  return this._class&&this._class.indexOf('dgrid-autoheight')>=0;
+		},
+		_setClass:function(){
+			var before=this._hasAutoHeight();
+			this.inherited(arguments);
+			if (before!==this._hasAutoHeight()) //relink event
+				this._scrollEvent();
+		},
+		_scrollSignal:undefined,
+		_scrollEvent:function(){
+			var self=this;
+			if (this._scrollSignal)
+			  this._scrollSignal.remove();
+			var node=this.bodyNode;
+			if (this._hasAutoHeight())
+			  node=this.params.parentNode||window;
+			this._scrollSignal=on(node, 'scroll',
+				miscUtil[this.pagingMethod](function (event) {
+					self._processScroll(event);
+				}, null, this.pagingDelay)
+			);
+		},
 		_processScroll: function (evt) {
 			// summary:
 			//		Checks to make sure that everything in the viewable area has been
@@ -345,7 +356,25 @@ define([
 				// References related to emitting dgrid-refresh-complete if applicable
 				lastRows,
 				preloadSearchNext = true;
+			if (this._hasAutoHeight()){
+				var parentNode=this.params.parentNode||window;
 
+var cumulativeOffset = function(element) {
+    var top = 0, left = 0;
+    do {
+        top += element.offsetTop  || 0;
+        left += element.offsetLeft || 0;
+        element = element.offsetParent;
+    } while(element);
+
+    return {
+        top: top,
+        left: left
+    };
+};
+				visibleTop=Math.max(0,parentNode.scrollY-cumulativeOffset(scrollNode).top);
+				visibleBottom=parentNode.innerHeight+visibleTop;
+			}
 			// XXX: I do not know why this happens.
 			// munging the actual location of the viewport relative to the preload node by a few pixels in either
 			// direction is necessary because at least WebKit on Windows seems to have an error that causes it to


### PR DESCRIPTION
issue with full storage loading
its can be tested on https://github.com/SitePen/dgrid/blob/master/test/Rest.html
with adding to creation object 
<code>class:'dgrid-autoheight'</code>
or set  after creation with code
<code>window.grid.set('class','dgrid-autoheight');</code>

with this path grid loaded properly by pages
i used function <code>cumulativeOffset</code> for calculating relative position to window(or parentNode ) 
maybe dojo has  function intended for it?