### PR TITLE
Update Editor.js

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -402,7 +402,7 @@ define([
 				}
 
 				if (editor === 'textarea') {
-					tagName === 'textarea';
+					tagName = 'textarea';
 				}
 				else {
 					tagName = 'input';


### PR DESCRIPTION
This fixes a little typo in Editor.js, which causes the "TypeError: node is null" error, when you want to use textarea control as an editor in grid.