### PR TITLE
Update dgrid tests for Intern 3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-stylus');
 	grunt.loadNpmTasks('grunt-contrib-watch');
-	grunt.loadNpmTasks('intern-geezer');
+	grunt.loadNpmTasks('intern');
 
 	// grunt-contrib-stylus does not appear to support globbed destination filenames,
 	// so generate the desired destination/source configuration ahead of time

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"grunt-contrib-clean": "~0.6.0",
 		"grunt-contrib-stylus": "~0.20",
 		"grunt-contrib-watch": "~0.6.1",
-		"intern-geezer": "~2.2",
+		"intern": "3.0.0",
 		"nib": "~1.0.4"
 	},
 	"directories": {

--- a/test/intern/functional/Editor.js
+++ b/test/intern/functional/Editor.js
@@ -106,7 +106,7 @@ define([
 			// Generates test functions for enter/blur value registration tests
 			return function () {
 				this.async(60000);
-				var command = new EditorCommand(this.get('remote'));
+				var command = new EditorCommand(this.remote);
 
 				command = command.get(require.toUrl('./Editor.html'))
 					.then(pollUntil(function () {
@@ -128,7 +128,7 @@ define([
 		function createFocusTest(selector, initFunction) {
 			// Generates test functions for focus preservation tests
 			return function () {
-				var command = new EditorCommand(this.get('remote')),
+				var command = new EditorCommand(this.remote),
 					rowIndex;
 
 				function each(rowIndex) {
@@ -181,7 +181,7 @@ define([
 
 		function createEscapeRevertTest(initFunction) {
 			return function () {
-				var command = new EditorCommand(this.get('remote')),
+				var command = new EditorCommand(this.remote),
 					rowIndex;
 
 				function each(rowIndex) {
@@ -237,7 +237,7 @@ define([
 
 		function createAutosaveTest(initFunction) {
 			return function () {
-				var command = new EditorCommand(this.get('remote')),
+				var command = new EditorCommand(this.remote),
 					appendValue = 'abc',
 					rowIndex;
 
@@ -301,7 +301,7 @@ define([
 			// In order to function properly on all platforms, we need to know
 			// what the proper character sequence is to go to the end of a text field.
 			// End key works generally everywhere except Mac OS X.
-			return util.isInputHomeEndSupported(this.get('remote')).then(function (isSupported) {
+			return util.isInputHomeEndSupported(this.remote).then(function (isSupported) {
 				gotoEnd = isSupported ? function (command) {
 					return command.type(keys.END);
 				} : function (command) {

--- a/test/intern/functional/Keyboard.js
+++ b/test/intern/functional/Keyboard.js
@@ -8,7 +8,7 @@ define([
 	function testUpDownKeys(gridId, cellNavigation) {
 		var rootQuery = '#' + gridId + ' #' + gridId + '-row-';
 		return function () {
-			return this.get('remote')
+			return this.remote
 				.findByCssSelector(rootQuery + '0' + (cellNavigation ? ' .dgrid-column-col1' : ''))
 					.click()
 					.type([keys.ARROW_DOWN])
@@ -36,7 +36,7 @@ define([
 	function testLeftRightKeys(gridId, header) {
 		var rootQuery = header ? ('#' + gridId + ' .dgrid-header') : ('#' + gridId + ' #' + gridId + '-row-0');
 		return function () {
-			return this.get('remote')
+			return this.remote
 				.findByCssSelector(rootQuery + ' .dgrid-column-col1')
 					.click()
 					.type([keys.ARROW_RIGHT])
@@ -64,7 +64,7 @@ define([
 	function testHomeEndKeys(gridId, cellNavigation) {
 		var rootQuery = '#' + gridId + ' #' + gridId + '-row-';
 		return function () {
-			return this.get('remote')
+			return this.remote
 				.findByCssSelector(rootQuery + '0' + (cellNavigation ? ' .dgrid-column-col1' : ''))
 					.click()
 					.type([keys.END])
@@ -97,7 +97,7 @@ define([
 			// since this functional test module runs on the server and can't load
 			// such scripts. Further, in the html page, set a global "ready" var
 			// to true to tell the runner to continue.
-			return this.get('remote')
+			return this.remote
 				.get(require.toUrl('./Keyboard.html'))
 				.then(pollUntil(function () {
 					return window.ready;

--- a/test/intern/functional/KeyboardTab.js
+++ b/test/intern/functional/KeyboardTab.js
@@ -12,7 +12,7 @@ define([
 			// since this functional test module runs on the server and can't load
 			// such scripts. Further, in the html page, set a global "ready" var
 			// to true to tell the runner to continue.
-			return this.get('remote')
+			return this.remote
 				.get(require.toUrl('./KeyboardTab.html'))
 				.then(pollUntil(function () {
 					return window.ready;
@@ -20,7 +20,7 @@ define([
 		});
 
 		test.test('grids with and without headers -> tab key', function () {
-			return this.get('remote')
+			return this.remote
 				.getActiveElement()
 					.getAttribute('id')
 					.then(function (id) {

--- a/test/intern/functional/Selector.js
+++ b/test/intern/functional/Selector.js
@@ -97,7 +97,7 @@ define([
 				}
 
 				var selector = '#' + gridId + '-row-',
-					remote = this.get('remote'),
+					remote = this.remote,
 					rowIndex;
 
 				function each(rowIndex) {
@@ -134,7 +134,7 @@ define([
 		}
 
 		test.before(function () {
-			var remote = this.get('remote');
+			var remote = this.remote;
 			return remote.get(require.toUrl('./Selector.html'))
 				.then(pollUntil(function () {
 					return window.ready;
@@ -152,7 +152,7 @@ define([
 
 		test.beforeEach(function () {
 			// Clear selections from previous tests
-			return this.get('remote').execute(function () {
+			return this.remote.execute(function () {
 				/* global gridExtended, gridMultiple, gridSingle, gridToggle, gridNone */
 				gridExtended.clearSelection();
 				gridMultiple.clearSelection();

--- a/test/intern/functional/Tree.js
+++ b/test/intern/functional/Tree.js
@@ -13,7 +13,7 @@ define([
 			var xOffset = 0;
 			// Nudge the y-offset of the cursor down a bit for good measure (default seems to be 0,0 in the target
 			// element; in Firefox the click has been known to hit just above the target element)
-			var remote = this.get('remote');
+			var remote = this.remote;
 
 			if (remote.environmentType.browserName === 'safari') {
 				console.warn('Warning: skipping a tree functional test because ' +
@@ -58,7 +58,7 @@ define([
 	test.suite('dgrid/tree functional tests', function () {
 
 		test.before(function () {
-			var remote = this.get('remote');
+			var remote = this.remote;
 
 			return remote.get(require.toUrl('./Tree.html'))
 				.then(pollUntil(function () {

--- a/test/intern/intern.js
+++ b/test/intern/intern.js
@@ -1,66 +1,67 @@
-define([
-	'intern/dojo/has'
-], function (has) {
-	return {
-		// The port on which the instrumenting proxy will listen
-		proxyPort: 9000,
+var dojoConfig = { async: true };
+define({
+	// The port on which the instrumenting proxy will listen
+	proxyPort: 9000,
 
-		// A fully qualified URL to the Intern proxy
-		proxyUrl: 'http://localhost:9000/',
+	// A fully qualified URL to the Intern proxy
+	proxyUrl: 'http://localhost:9000/',
 
-		// Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
-		// specified browser environments in the `environments` array below as well. See
-		// https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
-		// https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
-		// Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
-		// automatically
-		capabilities: {
-			// Limit duration of each job to avoid waste of resources during hangs
-			'max-duration': 600,
-			// Increase timeout if Sauce Labs receives no new commands
-			// (no commands are sent during non-functional unit tests)
-			'idle-timeout': 180
-		},
+	// Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
+	// specified browser environments in the `environments` array below as well. See
+	// https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
+	// https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
+	// Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
+	// automatically
+	capabilities: {
+		// Limit duration of each job to avoid waste of resources during hangs
+		'max-duration': 600,
+		// Increase timeout if Sauce Labs receives no new commands
+		// (no commands are sent during non-functional unit tests)
+		'idle-timeout': 180
+	},
 
-		// Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
-		// OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
-		// capabilities options specified for an environment will be copied as-is
-		environments: [
-			{ browserName: 'internet explorer', version: '11', platform: 'Windows 8.1' },
-			{ browserName: 'internet explorer', version: '10', platform: 'Windows 8' },
-			{ browserName: 'internet explorer', version: '9', platform: 'Windows 7' },
-			{ browserName: 'firefox', platform: [ 'Linux', 'OS X 10.6', 'Windows 7' ] },
-			{ browserName: 'chrome', platform: [ 'Linux', 'OS X 10.8', 'Windows 7' ] },
-			{ browserName: 'safari', version: '6', platform: 'OS X 10.8' }
-		],
+	// Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
+	// OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
+	// capabilities options specified for an environment will be copied as-is
+	environments: [
+		{ browserName: 'internet explorer', version: '11', platform: 'Windows 8.1' },
+		{ browserName: 'internet explorer', version: '10', platform: 'Windows 8' },
+		{ browserName: 'internet explorer', version: '9', platform: 'Windows 7' },
+		{ browserName: 'firefox', platform: [ 'Linux', 'OS X 10.6', 'Windows 7' ] },
+		{ browserName: 'chrome', platform: [ 'Linux', 'OS X 10.8', 'Windows 7' ] },
+		{ browserName: 'safari', version: '6', platform: 'OS X 10.8' }
+	],
 
-		// Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-		maxConcurrency: 3,
+	// Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
+	maxConcurrency: 3,
 
-		// If using Sauce Labs, keep your username and password in the SAUCE_USERNAME and SAUCE_ACCESS_KEY
-		// environment variables.
-		tunnel: 'SauceLabsTunnel',
+	// If using Sauce Labs, keep your username and password in the SAUCE_USERNAME and SAUCE_ACCESS_KEY
+	// environment variables.
+	tunnel: 'SauceLabsTunnel',
 
-		// Configuration options for the module loader;
-		// any AMD configuration options supported by the Dojo loader can be used here
-		loader: {
-			baseUrl: has('host-browser') ? '../../..' : '..',
-			// Packages that should be registered with the loader in each testing environment
-			packages: [
-				{ name: 'dojo', location: 'dojo' },
-				{ name: 'dijit', location: 'dijit' },
-				{ name: 'dgrid', location: 'dgrid' },
-				{ name: 'dstore', location: 'dstore' }
-			]
-		},
+	basePath: '..',
 
-		// A regular expression matching URLs to files that should not be included in code coverage analysis
-		excludeInstrumentation: /^dojox?|^dijit|^dstore|\/node_modules\/|\/test\/|\/nls\//,
+	// Configuration options for the module loader;
+	// any AMD configuration options supported by the Dojo loader can be used here
+	loaders: {
+		'host-browser': 'dojo/dojo.js'
+	},
+	loaderOptions: {
+		// Packages that should be registered with the loader in each testing environment
+		packages: [
+			{ name: 'dojo', location: 'dojo' },
+			{ name: 'dijit', location: 'dijit' },
+			{ name: 'dgrid', location: 'dgrid' },
+			{ name: 'dstore', location: 'dstore' }
+		]
+	},
 
-		// Non-functional test suite(s) to run in each browser
-		suites: [ 'dgrid/test/intern/all' ],
+	// A regular expression matching URLs to files that should not be included in code coverage analysis
+	excludeInstrumentation: /^dojox?|^dijit|^dstore|\/node_modules\/|\/test\/|\/nls\//,
 
-		// Functional test suite(s) to run in each browser once non-functional tests are completed
-		functionalSuites: [ 'dgrid/test/intern/functional' ]
-	};
+	// Non-functional test suite(s) to run in each browser
+	suites: [ 'dgrid/test/intern/all' ],
+
+	// Functional test suite(s) to run in each browser once non-functional tests are completed
+	functionalSuites: [ 'dgrid/test/intern/functional' ]
 });

--- a/test/intern/runTests.html
+++ b/test/intern/runTests.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>dgrid Intern suite</title>
-		<meta http-equiv="refresh" content="0;url=../../node_modules/intern-geezer/client.html?config=test/intern/intern">
+		<meta http-equiv="refresh" content="0;url=../../node_modules/intern/client.html?config=test/intern/intern">
 	</head>
 	<body>
 		Redirecting to Intern runner.


### PR DESCRIPTION
Don’t land this yet (Intern 3 isn’t released so the package.json points to master). These are all the changes needed to make dgrid’s tests run in Intern 3.