### PR TITLE
Fix missing loadingMessage

### DIFF
--- a/extensions/Pagination.js
+++ b/extensions/Pagination.js
@@ -601,7 +601,9 @@ define([
 
 					return results;
 				}, function (error) {
-					cleanupLoading(grid);
+					if (this._topLevelRequest) {
+						cleanupLoading(grid);
+					}
 					throw error;
 				});
 			});


### PR DESCRIPTION
loadingMessage vanishes if gotoPage function gets called before previous page request returned. Call cleanupLoading only if no top level request is currently active.

Example: quickly change sort order by clicking a column header at http://dgrid.io/tutorials/0.4/grids_and_stores/demo/messages.html