### PR TITLE
fix memory leak inside ColumnReorder extension

### DIFF
--- a/extensions/ColumnReorder.js
+++ b/extensions/ColumnReorder.js
@@ -169,6 +169,12 @@ define([
 
 			// After header is rendered, set up a dnd source on each of its subrows.
 
+			if (this._columnDndSources) {
+				// Destroy old dnd sources.
+				arrayUtil.forEach(this._columnDndSources, function (source) {
+					source.destroy();
+				});
+			}
 			this._columnDndSources = [];
 
 			if (this.columnSets) {


### PR DESCRIPTION
destroy the _columnDndSources before assigning a new empty array
