### PR TITLE
Resize in response to window resize events, only when visible

### DIFF
--- a/List.js
+++ b/List.js
@@ -93,7 +93,7 @@ define([
 
 	// window resize event handler, run in context of List instance
 	var winResizeHandler = function () {
-		if (this._started) {
+		if (this._started && this.domNode.offsetParent) {
 			this.resize();
 		}
 	};


### PR DESCRIPTION
Resizing the grid in response to resize events, when the grid is not visible, is not helpful, and it only smashes the header.