### PR TITLE
Add migration documentation for the `sort` property

### DIFF
--- a/doc/migrating/0.4-Migration.md
+++ b/doc/migrating/0.4-Migration.md
@@ -106,6 +106,17 @@ var grid = new OnDemandGrid({
 }, 'grid');
 ```
 
+Sorting could be performed by setting the `sort` property to an array of objects with `attribute` and (optionally) `descending` properties:
+
+```js
+var grid = new OnDemandGrid({
+	store: store,
+	columns: { /* Define columns... */ },
+	// sort in descending order by the "title" property
+	sort: [ { attribute: 'title', descending: true } ]
+}, 'grid');
+```
+
 #### dgrid 0.4
 
 In dgrid 0.4, the `store` and `query` properties have been replaced by the `collection` property.
@@ -161,6 +172,17 @@ on(largeButtonNode, 'click', function () {
 	// When the "large" button is clicked, display only the large items.
 	grid.set('collection', store.filter({ size: 'large' }));
 });
+```
+
+When you want to sort the displayed items by multiple properties, set `sort` to an array of objects where each object contains a property named `property` identifying the data field to sort, and optionally a descending property which, if true, indicates to sort descending rather than ascending.
+
+```js
+var grid = new OnDemandGrid({
+	store: store,
+	columns: { /* Define columns... */ },
+	// sort in descending order by the "title" property
+	sort: [ { property: 'title', descending: true } ]
+}, 'grid');
 ```
 
 Further information on using dstore with dgrid 0.4 is available in the updated
@@ -490,7 +512,7 @@ var grid = new (declare([ OnDemandGrid, Tree ]))({
 ```
 
 If you need to define the `getChildren` and `mayHaveChildren` methods yourself, it's worth looking at the source of the
-[`dstore/Tree`](https://github.com/SitePen/dstore/blob/master/Tree.js) module to see its usage of the `root` property.
+[`dstore/Tree`](https://github.com/SitePen/dstore/blob/master/src/Tree.js) module to see its usage of the `root` property.
 When dstore's `filter` method is called, it returns a new sub-collection. The data in the sub-collection is different
 from the collection that generated it, but other properties from the original collection are copied to the
 sub-collection. This enables the `root` property to be available to any sub-collections (or sub-sub-collections).


### PR DESCRIPTION
Addresses #1186 by adding documentation explaining how the `sort` property differs between 0.3 and 0.4. Also fixes a broken URL in the same document.