### PR TITLE
Ignore click events when resizing columns.

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -268,9 +268,9 @@ define([
 			if (this._sortListener) {
 				this._sortListener.remove();
 			}
-			this._sortListener = listen(row, 'click,keydown', function (event) {
+			this._sortListener = listen(row, 'mouseup,keydown', function (event) {
 				// respond to click, space keypress, or enter keypress
-				if (event.type === 'click' || event.keyCode === 32 ||
+				if (event.type === 'mouseup' || event.keyCode === 32 ||
 						(!has('opera') && event.keyCode === 13)) {
 					var target = event.target;
 					var field;

--- a/extensions/ColumnResizer.js
+++ b/extensions/ColumnResizer.js
@@ -174,6 +174,8 @@ define([
 		//		browser would otherwise stretch all columns to span the grid.
 		adjustLastColumn: true,
 
+		_isResizingColumn: false, // flag indicating whether a column is currently being resized
+
 		_resizedColumns: false, // flag indicating if resizer has converted column widths to px
 
 		buildRendering: function () {
@@ -297,10 +299,16 @@ define([
 
 			if (!grid.mouseMoveListen) {
 				// establish listeners for initiating, dragging, and finishing resize
+				listen(grid.headerNode, 'dgrid-sort', function (event) {
+					if (grid._isResizingColumn) {
+						event.preventDefault();
+					}
+				});
 				listen(grid.headerNode,
 					'.dgrid-resize-handle:mousedown' +
 						(has('touch') ? ',.dgrid-resize-handle:touchstart' : ''),
 					function (e) {
+						grid._isResizingColumn = true;
 						grid._resizeMouseDown(e, this);
 						grid.mouseMoveListen.resume();
 						grid.mouseUpListen.resume();
@@ -316,6 +324,7 @@ define([
 				grid._listeners.push(grid.mouseUpListen = listen.pausable(document,
 					'mouseup' + (has('touch') ? ',touchend' : ''),
 					function (e) {
+						grid._isResizingColumn = false;
 						grid._resizeMouseUp(e);
 						grid.mouseMoveListen.pause();
 						grid.mouseUpListen.pause();


### PR DESCRIPTION
Resolves #1147. While resizing columns in Chrome and IE, `click` events are still emitted, with the result that if the cursor is over the column header when the mouse is released, then the grid data will be resorted. Particularly tricky is the fact that sorting is triggered by a `click` event, whereas resizing is managed by `mousedown` and `mouseup` event, so even if an "is resizing" flag is set by `ColumnResizer`, it will once again be `false` by the time the sorting `click` event is fired.

To get around this, column sorting is now also triggered by a `mouseup` event instead of a `click` event. Unit tests are still passing in IE11, latest Chrome, and latest FF, and functional tests are still passing in Chrome and FF (I still need to set up my VM to run these tests in IE).