### PR TITLE
Add refreshCell method to re-render a single cell

### DIFF
--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -6,8 +6,9 @@ define([
 	'dojo/dom-construct',
 	'dojo/has',
 	'dojo/on',
-	'dojo/when'
-], function (declare, lang, Deferred, aspect, domConstruct, has, on, when) {
+	'dojo/when',
+	'./Grid'
+], function (declare, lang, Deferred, aspect, domConstruct, has, on, when, Grid) {
 	// This module isolates the base logic required by store-aware list/grid
 	// components, e.g. OnDemandList/Grid and the Pagination extension.
 
@@ -221,6 +222,26 @@ define([
 			}
 
 			return result;
+		},
+
+		refreshCell: function (cell) {
+			var row = cell.row;
+			var self = this;
+
+			return this.collection.get(row.id).then(function (item) {
+				var cellElement = cell.element;
+				if (cellElement.widget) {
+					cellElement.widget.destroyRecursive();
+				}
+				domConstruct.empty(cellElement);
+
+				var dirtyItem = self.dirty && self.dirty[row.id];
+				if (dirtyItem) {
+					item = lang.delegate(item, dirtyItem);
+				}
+
+				self._createBodyRowCell(cellElement, cell.column, item);
+			});
 		},
 
 		renderArray: function () {

--- a/test/intern/core/_StoreMixin.js
+++ b/test/intern/core/_StoreMixin.js
@@ -5,6 +5,7 @@ define([
 	'dojo/_base/declare',
 	'dojo/aspect',
 	'dojo/Deferred',
+	'dijit/form/TextBox',
 	'dgrid/OnDemandList',
 	// column.set can't be tested independently from a Grid,
 	// so we are testing through OnDemandGrid for now.
@@ -13,7 +14,7 @@ define([
 	'dgrid/test/data/createSyncStore',
 	'dgrid/test/data/genericData',
 	'dojo/domReady!'
-], function (test, assert, lang, declare, aspect, Deferred,
+], function (test, assert, lang, declare, aspect, Deferred, TextBox,
 		OnDemandList, OnDemandGrid, ColumnSet, createSyncStore, genericData) {
 
 	// Helper method used to set column set() methods for various grid compositions
@@ -76,6 +77,54 @@ define([
 
 		test.afterEach(function () {
 			grid.destroy();
+		});
+
+		test.suite('_StoreMixin#refreshCell', function () {
+			var store;
+
+			test.beforeEach(function () {
+				store = createSyncStore({ data: genericData });
+				grid = new OnDemandList({
+					columns: {
+						col1: 'Column 1',
+						col3: {
+							label: 'Column 3',
+							editor: 'TextBox'
+						}
+					},
+					collection: store
+				});
+				document.body.appendChild(grid.domNode);
+				grid.startup();
+			});
+
+			test.test('no change', function () {
+				// TODO: debug: why is grid rendering as if no columns have been specified?
+				var cell = grid.cell('2', 'col1');
+				var oldValue = cell.element.innerHTML;
+
+				grid.refreshCell(cell);
+				assert.strictEqual(cell.element.innerHTML, oldValue, 'Cell value should not have changed');
+			});
+
+			test.test('change', function () {
+				// TODO: debug: why is grid rendering as if no columns have been specified?
+				var cell = grid.cell('2', 'col1');
+				var newValue = 'new value';
+
+				cell.row.data.col3 = newValue;
+				grid.refreshCell(cell);
+				assert.strictEqual(cell.element.innerHTML, newValue, 'Cell value should have changed');
+			});
+
+			test.test('widget destruction', function () {
+				// TODO: debug: why is grid rendering as if no columns have been specified?
+				var cell = grid.cell('2', 'col3');
+				var widget = cell.element.widget;
+
+				grid.refreshCell(cell);
+				assert.isTrue(widget._destroyed, 'Cell\'s editor widget should be destroyed');
+			});
 		});
 
 		test.suite('_StoreMixin#_setCollection', function () {

--- a/test/intern/core/_StoreMixin.js
+++ b/test/intern/core/_StoreMixin.js
@@ -6,6 +6,7 @@ define([
 	'dojo/aspect',
 	'dojo/Deferred',
 	'dijit/form/TextBox',
+	'dgrid/Editor',
 	'dgrid/OnDemandList',
 	// column.set can't be tested independently from a Grid,
 	// so we are testing through OnDemandGrid for now.
@@ -14,7 +15,7 @@ define([
 	'dgrid/test/data/createSyncStore',
 	'dgrid/test/data/genericData',
 	'dojo/domReady!'
-], function (test, assert, lang, declare, aspect, Deferred, TextBox,
+], function (test, assert, lang, declare, aspect, Deferred, TextBox, Editor,
 		OnDemandList, OnDemandGrid, ColumnSet, createSyncStore, genericData) {
 
 	// Helper method used to set column set() methods for various grid compositions
@@ -84,12 +85,12 @@ define([
 
 			test.beforeEach(function () {
 				store = createSyncStore({ data: genericData });
-				grid = new OnDemandList({
+				grid = new declare([OnDemandGrid, Editor])({
 					columns: {
 						col1: 'Column 1',
 						col3: {
 							label: 'Column 3',
-							editor: 'TextBox'
+							editor: TextBox
 						}
 					},
 					collection: store
@@ -99,31 +100,34 @@ define([
 			});
 
 			test.test('no change', function () {
-				// TODO: debug: why is grid rendering as if no columns have been specified?
 				var cell = grid.cell('2', 'col1');
 				var oldValue = cell.element.innerHTML;
 
-				grid.refreshCell(cell);
-				assert.strictEqual(cell.element.innerHTML, oldValue, 'Cell value should not have changed');
+				return grid.refreshCell(cell).then(function () {
+					assert.strictEqual(cell.element.innerHTML, oldValue, 'Cell value should not change');
+				});
 			});
 
 			test.test('change', function () {
-				// TODO: debug: why is grid rendering as if no columns have been specified?
 				var cell = grid.cell('2', 'col1');
+				var oldValue = cell.element.innerHTML;
 				var newValue = 'new value';
 
-				cell.row.data.col3 = newValue;
-				grid.refreshCell(cell);
-				assert.strictEqual(cell.element.innerHTML, newValue, 'Cell value should have changed');
+				cell.row.data.col1 = newValue;
+				assert.strictEqual(cell.element.innerHTML, oldValue, 'Cell value should not change');
+
+				return grid.refreshCell(cell).then(function () {
+					assert.strictEqual(cell.element.innerHTML, newValue, 'Cell value should change');
+				});
 			});
 
 			test.test('widget destruction', function () {
-				// TODO: debug: why is grid rendering as if no columns have been specified?
 				var cell = grid.cell('2', 'col3');
 				var widget = cell.element.widget;
 
-				grid.refreshCell(cell);
-				assert.isTrue(widget._destroyed, 'Cell\'s editor widget should be destroyed');
+				return grid.refreshCell(cell).then(function () {
+					assert.isTrue(widget._destroyed, 'Cell\'s editor widget should be destroyed');
+				});
 			});
 		});
 


### PR DESCRIPTION
This PR adds `_StoreMixin#refreshCell` which will accept a `cell` object (as returned by `Grid#cell`) and re-render the cell (without affecting the rest of the row).

Some logic in `Grid#renderRow` was refactored into `Grid#_createBodyRowCell` to facilitate writing `_StoreMixin#refreshCell`.