### PR TITLE
Prevent notifications from causing a request for page 0

### DIFF
--- a/extensions/Pagination.js
+++ b/extensions/Pagination.js
@@ -462,7 +462,7 @@ define([
 
 			if (needsRefresh) {
 				// Refresh the current page to maintain correct number of rows on page
-				this.gotoPage(Math.min(this._currentPage, Math.ceil(event.totalLength / this.rowsPerPage)));
+				this.gotoPage(Math.min(this._currentPage, Math.ceil(event.totalLength / this.rowsPerPage)) || 1);
 			}
 			// If we're not updating the whole page, check if we at least need to update status/navigation
 			else if (collection === this._renderedCollection && event.totalLength !== this._total) {

--- a/test/intern/extensions/Pagination.js
+++ b/test/intern/extensions/Pagination.js
@@ -92,6 +92,17 @@ define([
 			grid.collection.removeSync(100);
 			testAssertions(100, 10);
 		});
+
+		test.test('Should never pass 0 to gotoPage in _onNotification', function() {
+			var pageNumber;
+			grid.gotoPage = function(page) {
+				pageNumber = page;
+			};
+
+			grid._onNotification([], { previousIndex: 0, totalLength: 0, type: 'delete'});
+
+			assert.strictEqual(pageNumber, 1, 'Should have passed page 1');
+		});
 	});
 
 	test.suite('Pagination size selector initialization tests', function () {


### PR DESCRIPTION
Fixes #1192 by ensuring that _onNotification never passes 0 to gotoPage