### PR TITLE
Continue to listen for transitionend events, after the first one. The

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -140,10 +140,12 @@ define([
 						});
 					}
 
-					if (hasTransitionend && !noTransition) {
-						on.once(container, hasTransitionend, this._onTreeTransitionEnd);
+					if (hasTransitionend) {
+						// we transitions are supported, always listen
+						on(container, hasTransitionend, this._onTreeTransitionEnd);
 					}
-					else {
+					if (!hasTransitionend || noTransition) {
+						// if we are not, or can not do transition, end the transition immediately
 						this._onTreeTransitionEnd.call(container);
 					}
 				}


### PR DESCRIPTION
container only gets created once, so we need to listen for more than the
first transitionend event, in order to remove the fixed height that breaks
scrolling, fixes #1069