### PR TITLE
Fix #614 - Remove check for grid's collection in Tree mixin.

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -60,8 +60,8 @@ define([
 				promise;
 
 			target = row.element;
-			target = target && (target.className.indexOf('dgrid-expando-icon') > -1 ? target :
-				querySelector('.dgrid-expando-icon', target)[0]);
+			target = target.className.indexOf('dgrid-expando-icon') > -1 ? target :
+				querySelector('.dgrid-expando-icon', target)[0];
 
 			noTransition = noTransition || !this.enableTreeTransitions;
 

--- a/Tree.js
+++ b/Tree.js
@@ -60,8 +60,8 @@ define([
 				promise;
 
 			target = row.element;
-			target = target.className.indexOf('dgrid-expando-icon') > -1 ? target :
-				querySelector('.dgrid-expando-icon', target)[0];
+			target = target && (target.className.indexOf('dgrid-expando-icon') > -1 ? target :
+				querySelector('.dgrid-expando-icon', target)[0]);
 
 			noTransition = noTransition || !this.enableTreeTransitions;
 
@@ -323,10 +323,6 @@ define([
 
 			var grid = this,
 				colSelector = '.dgrid-content .dgrid-column-' + column.id;
-
-			if (!grid.collection) {
-				throw new Error('dgrid Tree mixin requires a collection to operate.');
-			}
 
 			if (typeof column.renderExpando !== 'function') {
 				column.renderExpando = this._defaultRenderExpando;

--- a/test/intern/mixins/Tree-expand-promise.js
+++ b/test/intern/mixins/Tree-expand-promise.js
@@ -70,7 +70,6 @@ define([
 
 		function createGrid(store) {
 			grid = new (declare([ OnDemandGrid, Tree ]))({
-				collection: store.getRootCollection(),
 				columns: [
 					{renderExpando: true, field: 'node', label: 'Node'},
 					{field: 'value', label: 'Value'}
@@ -78,6 +77,7 @@ define([
 			});
 			document.body.appendChild(grid.domNode);
 			grid.startup();
+			grid.set('collection', store.getRootCollection());
 		}
 
 		function createNoRenderQueryGrid(store) {

--- a/test/intern/mixins/Tree.js
+++ b/test/intern/mixins/Tree.js
@@ -150,26 +150,6 @@ define([
 			};
 		}
 
-		test.suite('no store', function () {
-
-			test.afterEach(destroyGrid);
-
-			test.test('call expand', function () {
-				grid = new (declare([OnDemandGrid, Tree]))(
-					{
-						columns: [
-							{ renderExpando: true, label: 'id', field: 'id' },
-							{ label: 'value', field: 'value' }
-						]
-					}
-				);
-				document.body.appendChild(grid.domNode);
-				grid.startup();
-
-				grid.expand(0);
-			});
-		});
-
 		test.suite('configure store last', function () {
 
 			test.beforeEach(makeBeforeEach(true));

--- a/test/intern/mixins/Tree.js
+++ b/test/intern/mixins/Tree.js
@@ -24,7 +24,7 @@ define([
 		testDelay = 15,
 		hasTransitionEnd = has('transitionend');
 
-	function createGrid(options) {
+	function createGrid(options, setStoreAfterStartup) {
 		var data = [],
 			store,
 			treeColumnOptions,
@@ -70,7 +70,7 @@ define([
 
 		grid = new GridConstructor(lang.mixin({
 			sort: 'id',
-			collection: store,
+			collection: setStoreAfterStartup ? null : store,
 			columns: [
 				treeColumnOptions,
 				{ label: 'value', field: 'value'}
@@ -78,6 +78,10 @@ define([
 		}, options && options.gridOptions));
 		document.body.appendChild(grid.domNode);
 		grid.startup();
+
+		if (setStoreAfterStartup) {
+			grid.set('collection', store);
+		}
 	}
 
 	function destroyGrid() {
@@ -135,15 +139,62 @@ define([
 	}
 
 	test.suite('Tree', function () {
-		test.suite('large family expansion', function () {
 
-			test.beforeEach(function () {
-				createGrid();
+		function makeBeforeEach(setStoreAfterStartup) {
+			return function () {
+				createGrid({}, setStoreAfterStartup);
 
 				// Firefox in particular seems to skip transitions sometimes
 				// if we don't wait a bit after creating and placing the grid
 				return wait();
+			};
+		}
+
+		test.suite('no store', function () {
+
+			test.afterEach(destroyGrid);
+
+			test.test('call expand', function () {
+				grid = new (declare([OnDemandGrid, Tree]))(
+					{
+						columns: [
+							{ renderExpando: true, label: 'id', field: 'id' },
+							{ label: 'value', field: 'value' }
+						]
+					}
+				);
+				document.body.appendChild(grid.domNode);
+				grid.startup();
+
+				grid.expand(0);
 			});
+		});
+
+		test.suite('configure store last', function () {
+
+			test.beforeEach(makeBeforeEach(true));
+
+			test.afterEach(destroyGrid);
+
+			test.test('expand first row', function () {
+				return expand(0)
+					.then(function () {
+						testRowExists('0:0');
+						testRowExists('0:99', false);
+					});
+			});
+
+			test.test('expand last row', function () {
+				return expand(4).then(function () {
+					testRowExists('4:0');
+					testRowExists('4:99', false);
+				});
+			});
+		});
+
+		test.suite('large family expansion', function () {
+
+			test.beforeEach(makeBeforeEach());
 
 			test.afterEach(destroyGrid);
 


### PR DESCRIPTION
Remove the check for a collection in the _configureTreeColumn method in the Tree mixin.  It is not necessary.  Add some new tests and modified some of the existing tests to set the grid's collection after startup.

Fix #614 