### PR TITLE
Remove shared editors before destroying dom on refresh

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -32,15 +32,6 @@ define([
 			});
 			this._listeners.push(this._editorFocusoutHandle);
 
-			aspect.before(this, 'refresh', function() {
-				var id;
-				for (id in this._editorInstances) {
-					var editorInstanceDomNode;
-					if ((editorInstanceDomNode = this._editorInstances[id].domNode) && editorInstanceDomNode.parentNode) {
-						editorInstanceDomNode.parentNode.removeChild(editorInstanceDomNode)
-					}
-				}
-			});
 		},
 
 		insertRow: function () {
@@ -52,6 +43,18 @@ define([
 				this.edit(this.cell(row, previouslyFocusedCell.column.id));
 			}
 			return rowElement;
+		},
+
+		refresh: function () {
+			var id;
+			for (id in this._editorInstances) {
+				var editorInstanceDomNode = this._editorInstances[ id ].domNode;
+				if (editorInstanceDomNode && editorInstanceDomNode.parentNode) {
+					editorInstanceDomNode.parentNode.removeChild(editorInstanceDomNode)
+				}
+			}
+
+			this.inherited(arguments);
 		},
 
 		removeRow: function (rowElement) {

--- a/Editor.js
+++ b/Editor.js
@@ -1,6 +1,7 @@
 define([
 	'dojo/_base/declare',
 	'dojo/_base/lang',
+	'dojo/aspect',
 	'dojo/Deferred',
 	'dojo/dom-construct',
 	'dojo/dom-class',
@@ -9,7 +10,7 @@ define([
 	'dojo/query',
 	'./Grid',
 	'dojo/_base/sniff'
-], function (declare, lang, Deferred, domConstruct, domClass, on, has, query, Grid) {
+], function (declare, lang, aspect, Deferred, domConstruct, domClass, on, has, query, Grid) {
 
 	return declare(null, {
 		constructor: function () {
@@ -30,6 +31,16 @@ define([
 				self._focusedEditorCell = null;
 			});
 			this._listeners.push(this._editorFocusoutHandle);
+
+			aspect.before(this, 'refresh', function() {
+				var id;
+				for (id in this._editorInstances) {
+					var editorInstanceDomNode;
+					if ((editorInstanceDomNode = this._editorInstances[id].domNode) && editorInstanceDomNode.parentNode) {
+						editorInstanceDomNode.parentNode.removeChild(editorInstanceDomNode)
+					}
+				}
+			});
 		},
 
 		insertRow: function () {

--- a/test/intern/mixins/Editor.js
+++ b/test/intern/mixins/Editor.js
@@ -14,9 +14,10 @@ define([
 	'dgrid/OnDemandGrid',
 	'dgrid/Editor',
 	'dgrid/test/data/createSyncStore',
-	'dgrid/test/data/orderedData'
+	'dgrid/test/data/orderedData',
+	'dstore/Memory'
 ], function (test, assert, declare, aspect, Deferred, on, all, query, when, registry, TextBox,
-		Grid, OnDemandGrid, Editor, createSyncStore, orderedData) {
+		Grid, OnDemandGrid, Editor, createSyncStore, orderedData, Memory) {
 
 	var testOrderedData = orderedData.items,
 		EditorGrid = declare([Grid, Editor]),
@@ -460,6 +461,41 @@ define([
 			testRow(0);
 
 			return dfd;
+		});
+
+		test.test('Maintain shared widgets on refresh in IE', function() {
+			var cell,
+				cellContent,
+				data = [],
+				i;
+
+			for (var i = 0; i < 10; i++) {
+				data.push({
+					id: i,
+					name: "Name " + i
+				});
+			}
+
+			grid = new (declare([OnDemandGrid, Editor]))({
+				columns: {
+					name: {
+						editor: TextBox,
+						editOn: 'click'
+					}
+				},
+				collection: new Memory({
+					data: data
+				})
+			});
+			document.body.appendChild(grid.domNode);
+			grid.startup();
+			cell = grid.cell(0, "name");
+			grid.edit(cell);
+			cellContent = cell.element.innerHTML;
+			grid.refresh();
+			cell = grid.cell(0, "name");
+			grid.edit(cell);
+			assert.isTrue(cell.element.innerHTML === cellContent, 'Content shouldn\'t have changed');
 		});
 	});
 });


### PR DESCRIPTION
Fixes #1100.

When the grid is refreshed, `contentNode.innerHTM` is set to `''`, and in IE this destroys the `innerHTML` of the `TextBox`. Since it's a shared editor, it is not recreated and the broken widget is still used after the refresh. By removing any shared widgets from the grid's dom before refreshing this is avoided. I've included a test case as well.