### PR TITLE
Preload all skins for skin test

### DIFF
--- a/test/skin.html
+++ b/test/skin.html
@@ -89,7 +89,7 @@
 				byId('skin').innerHTML = skinUtil.skin;
 
 				// add links to test all skins, w/ dgrid.css loaded first/last
-				byId('skins').innerHTML = skinUtil.renderLinks(skins);
+				byId('skins').appendChild(skinUtil.renderLinks(skins, grid));
 
 				createGrid(true);
 			});

--- a/test/skin.html
+++ b/test/skin.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=570">
 		<link rel="stylesheet" href="../../dojo/resources/dojo.css">
 		<link rel="stylesheet" href="../css/dgrid.css">
+		<link rel="stylesheet" href="../css/skins/claro.css">
+		<link rel="stylesheet" href="../css/skins/tundra.css">
+		<link rel="stylesheet" href="../css/skins/nihilo.css">
+		<link rel="stylesheet" href="../css/skins/soria.css">
+		<link rel="stylesheet" href="../css/skins/slate.css">
+		<link rel="stylesheet" href="../css/skins/sage.css">
+		<link rel="stylesheet" href="../css/skins/cactus.css">
 		<style>
 			h2 {
 				font-weight: bold;
@@ -37,6 +44,7 @@
 		<script src="../../dojo/dojo.js" data-dojo-config="async: true"></script>
 		<script>
 			var toggleUiClasses; // Function, defined later
+			var skins = ['claro', 'tundra', 'nihilo', 'soria', 'slate', 'sage', 'cactus'];
 			require([ 'dojo/_base/declare', 'dojo/dom-construct',
 				'dgrid/Grid', 'dgrid/Selection', 'dgrid/Keyboard', 'dgrid/Editor', 'dgrid/extensions/Pagination',
 				'dgrid/test/data/testStore', 'dgrid/test/skinUtil', 'dojo/domReady!' ],
@@ -81,7 +89,7 @@
 				byId('skin').innerHTML = skinUtil.skin;
 
 				// add links to test all skins, w/ dgrid.css loaded first/last
-				byId('skins').innerHTML = skinUtil.renderLinks();
+				byId('skins').innerHTML = skinUtil.renderLinks(skins);
 
 				createGrid(true);
 			});

--- a/test/skinUtil.js
+++ b/test/skinUtil.js
@@ -7,20 +7,14 @@ define([
 	// Honor skin and RTL specification from query param
 	var skin = params.skin || 'claro';
 	var rtl = params.dir === 'rtl';
-	var skins = ['claro', 'tundra', 'nihilo', 'soria', 'slate', 'sage', 'cactus'];
 
 	// Add skin class to body
 	document.body.className = skin;
 	// Add dir=rtl to body if specified in query
 	rtl && (document.body.dir = 'rtl');
 
-	var link = document.createElement('link');
-	link.rel = 'stylesheet';
-	link.href = require.toUrl('dgrid/css/skins/' + skin + '.css');
-	document.getElementsByTagName('head')[0].appendChild(link);
-
 	return {
-		renderLinks: function () {
+		renderLinks: function (skins) {
 			return arrayUtil.map(skins, function (s) {
 				return s === skin ? s :
 					'<a href="skin.html?skin=' + s + (rtl ? '&dir=rtl' : '') + '">' + s + '</a>';

--- a/test/skinUtil.js
+++ b/test/skinUtil.js
@@ -15,10 +15,17 @@ define([
 
 	return {
 		renderLinks: function (skins) {
-			return arrayUtil.map(skins, function (s) {
-				return s === skin ? s :
-					'<a href="skin.html?skin=' + s + (rtl ? '&dir=rtl' : '') + '">' + s + '</a>';
-			}).join(' / ');
+			var documentFragment = document.createDocumentFragment();
+			arrayUtil.forEach(skins, function (s) {
+					var button = document.createElement('button');
+					button.textContent = s;
+					button.onclick = function() {
+						document.body.className = button.textContent;
+						grid.resize();
+					};
+					documentFragment.appendChild(button);
+			});
+			return documentFragment;
 		},
 		rtl: rtl,
 		skin: skin


### PR DESCRIPTION
The issue with skins in edge seems to have actually been caused by the test, not an issue with the css. When the css is cached, or preloaded, the tests work as expected. The issue seems to be that the grid was being rendered before the css was completely loaded. I modified the test to load all the skins ahead of time.
Fix #1204