### PR TITLE
Delete expanded status of rows deleted from a tracked store

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -396,6 +396,19 @@ define([
 			});
 		},
 
+		_onNotification: function (rows, event) {
+			if (event.type === 'delete') {
+				var key;
+				for (key in this._expanded) {
+					var row = this.row(key);
+					if (!row || (!row.data && !row.element)) {
+						delete this._expanded[key];
+					}
+				}
+			}
+			this.inherited(arguments);
+		},
+
 		_onTreeTransitionEnd: function (event) {
 			var container = this,
 				height = this.style.height;

--- a/Tree.js
+++ b/Tree.js
@@ -398,13 +398,7 @@ define([
 
 		_onNotification: function (rows, event) {
 			if (event.type === 'delete') {
-				var key;
-				for (key in this._expanded) {
-					var row = this.row(key);
-					if (!row || (!row.data && !row.element)) {
-						delete this._expanded[key];
-					}
-				}
+				delete this._expanded[event.id];
 			}
 			this.inherited(arguments);
 		},

--- a/test/intern/mixins/Tree.js
+++ b/test/intern/mixins/Tree.js
@@ -412,16 +412,12 @@ define([
 
 			test.test('collapse items removed from store', function() {
 				return expand(0).then(function() {
-					assert.isTrue(grid.row(0).element.classList.contains('dgrid-row-expanded'),
+					assert.isTrue(domClass.contains(grid.row(0).element, 'dgrid-row-expanded'),
 						'Should have expanded class');
 					var item = grid.collection.getSync(0);
-					grid.removeRow(grid.row(0));
-					grid.refresh();
-					assert.isTrue(grid.row(0).element.classList.contains('dgrid-row-expanded'),
-						'Should preserve expanded status after removing row');
 					grid.collection.remove(0);
 					grid.collection.add(item);
-					assert.isFalse(grid.row(0).element.classList.contains('dgrid-row-expanded'),
+					assert.isFalse(domClass.contains(grid.row(0).element, 'dgrid-row-expanded'),
 						'Should not preserve expanded status after removing from store');
 				});
 			});

--- a/test/intern/mixins/Tree.js
+++ b/test/intern/mixins/Tree.js
@@ -409,6 +409,22 @@ define([
 					}, null, 'Modification of child should not throw error');
 				});
 			});
+
+			test.test('collapse items removed from store', function() {
+				return expand(0).then(function() {
+					assert.isTrue(grid.row(0).element.classList.contains('dgrid-row-expanded'),
+						'Should have expanded class');
+					var item = grid.collection.getSync(0);
+					grid.removeRow(grid.row(0));
+					grid.refresh();
+					assert.isTrue(grid.row(0).element.classList.contains('dgrid-row-expanded'),
+						'Should preserve expanded status after removing row');
+					grid.collection.remove(0);
+					grid.collection.add(item);
+					assert.isFalse(grid.row(0).element.classList.contains('dgrid-row-expanded'),
+						'Should not preserve expanded status after removing from store');
+				});
+			});
 		});
 
 		test.suite('Tree + Trackable + shouldTrackCollection: false', function () {


### PR DESCRIPTION
When a delete notification is received from a tracked store,
any entries in the `expanded` map missing from the grid are
deleted, This way, if the item is later added to the store
again it will not expand automatically.

Fix #997