### PR TITLE
Track and cleanup editor listeners on a per cell basis

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -82,7 +82,7 @@ define([
 						this._editorCellListeners[rowElement.id][key][i].remove();
 					}
 				}
-				this._editorCellListeners[rowElement.id] = {};
+				delete this._editorCellListeners[rowElement.id];
 			}
 			for (var i = this._alwaysOnWidgetColumns.length; i--;) {
 				// Destroy always-on editor widgets during the row removal operation,

--- a/Editor.js
+++ b/Editor.js
@@ -189,7 +189,7 @@ define([
 				// which we already advocate in docs for optimal use)
 
 				if (!options || !options.alreadyHooked) {
-					this._editorRowListeners[column.id] = on(cell, editOn, function () {
+					self._editorRowListeners[column.id] = on(cell, editOn, function () {
 						self._activeOptions = options;
 						self.edit(this);
 					});
@@ -457,8 +457,8 @@ define([
 							self._handleEditorChange(evt, column);
 						});
 					}
-					if (this._editorRowListeners) {
-						this._editorRowListeners[column.id] = handler;
+					if (self._editorRowListeners) {
+						self._editorRowListeners[column.id] = handler;
 					} else {
 						self._editorColumnListeners.push(handler);
 					}

--- a/Editor.js
+++ b/Editor.js
@@ -198,11 +198,13 @@ define([
 					if (self._editorRowListeners) {
 						self._editorRowListeners[column.id] = listener;
 					}
-					// We're in refresh cell since _editorRowListeners doesn't exist, so it's safe to assume
-					// that the row exists
+					// We're in refresh cell since _editorRowListeners doesn't exist, so the row
+					// should exist
 					else {
 						var row = self.row(object);
-						self._editorCellListeners[row.element.id][column.id] = listener;
+						if (row && row.element) {
+							self._editorCellListeners[row.element.id][column.id] = listener;
+						}
 					}
 				}
 
@@ -212,7 +214,7 @@ define([
 			} : function (object, value, cell, options) {
 				// always-on: create editor immediately upon rendering each cell
 				if (!column.canEdit || column.canEdit(object, value)) {
-					var cmp = self._createEditor(column);
+					var cmp = self._createEditor(column, object);
 					self._showEditor(cmp, column, cell, value);
 					// Maintain reference for later use.
 					cell[isWidget ? 'widget' : 'input'] = cmp;
@@ -406,7 +408,7 @@ define([
 			}
 		},
 
-		_createEditor: function (column) {
+		_createEditor: function (column, object) {
 			// Creates an editor instance based on column definition properties,
 			// and hooks up events.
 			var editor = column.editor,
@@ -480,7 +482,16 @@ define([
 					}
 					if (self._editorRowListeners) {
 						self._editorRowListeners[column.id] = listener;
-					} else {
+					}
+					// If object exists and editRowListeners doesn't, then we're here
+					// from refresh cell and we should be able to find the row
+					else if (object) {
+						var row = grid.row(object);
+						if (row && row.element) {
+							self._editorCellListeners[row.element.id][column.id] = listener;
+						}
+					}
+					else {
 						self._editorColumnListeners.push(listener);
 					}
 				}

--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -225,6 +225,7 @@ define([
 		},
 
 		refreshCell: function (cell) {
+			this.inherited(arguments);
 			var row = cell.row;
 			var self = this;
 


### PR DESCRIPTION
Added logic to track editor listeners on individual cells, and clean them up when the cell is re-rendered, in addition to when the columns are set. Some preliminary testing indicates that this has the desired effect(I.E. repeatedly refreshing the grid or re-rendering rows doesn't cause the number of listeners to keep increasing.)
The results from 0.4.0 and this branch can be compared by looking at these two JS fiddles: 
* 0.4.0: http://jsfiddle.net/mv09dtqr/1/
* This branch: http://jsfiddle.net/zh8tm6zb/5/

Clicking the button will refresh the grid 10 times, and each time log out the length of the `_editorColumnListeners` array, and in the case of this branch, the new object used to track the listeners for each cell. 
Fix #1211 
