### PR TITLE
Prevent default when shift clicking

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -246,6 +246,9 @@ define([
 					this._waitForMouseUp = target;
 				}
 				else {
+					if (event.shiftKey) {
+						event.preventDefault();
+					}
 					this[this._selectionHandlerName](event, target);
 				}
 			}


### PR DESCRIPTION
Prevents highlighting inappropriate HTML in Edge when selecting
multiple rows by shift clicking.

This fixes the issue in Edge, and based on my manual testing and the functional tests doesn't seem to cause any regressions.
Fixes #1203 