### PR TITLE
Only include visible columns in column resizing calculations

### DIFF
--- a/extensions/ColumnResizer.js
+++ b/extensions/ColumnResizer.js
@@ -1,5 +1,6 @@
 define([
 	'dojo/_base/declare',
+	'dojo/_base/array',
 	'dojo/on',
 	'dojo/query',
 	'dojo/_base/lang',
@@ -9,7 +10,7 @@ define([
 	'dojo/has',
 	'../util/misc',
 	'dojo/_base/html'
-], function (declare, listen, query, lang, dom, domConstruct, geom, has, miscUtil) {
+], function (declare, arrayUtil, listen, query, lang, dom, domConstruct, geom, has, miscUtil) {
 
 	function addRowSpan(table, span, startRow, column, id) {
 		// loop through the rows of the table and add this column's id to
@@ -25,7 +26,9 @@ define([
 
 		var i = subRows.length,
 			l = i,
-			numCols = subRows[0].length,
+			numCols = arrayUtil.filter(subRows[0], function (column) {
+				return !Boolean(column.hidden);
+			}).length,
 			table = new Array(i);
 
 		// create table-like structure in an array so it can be populated

--- a/test/intern/all.js
+++ b/test/intern/all.js
@@ -8,6 +8,7 @@ define([
 	'intern/node_modules/dojo/has!host-browser?./core/OnDemandList',
 	'intern/node_modules/dojo/has!host-browser?./core/trackable',
 	'intern/node_modules/dojo/has!host-browser?./extensions/ColumnHider',
+	'intern/node_modules/dojo/has!host-browser?./extensions/ColumnResizer',
 	'intern/node_modules/dojo/has!host-browser?./extensions/CompoundColumns',
 	'intern/node_modules/dojo/has!host-browser?./extensions/DijitRegistry',
 	'intern/node_modules/dojo/has!host-browser?./extensions/Pagination',

--- a/test/intern/extensions/ColumnResizer.js
+++ b/test/intern/extensions/ColumnResizer.js
@@ -1,0 +1,28 @@
+define([
+	'intern!tdd',
+	'dojo/_base/declare',
+	'dgrid/Grid',
+	'dgrid/extensions/ColumnHider',
+	'dgrid/extensions/ColumnResizer'
+], function (test, declare, Grid, ColumnHider, ColumnResizer) {
+
+	test.suite('ColumnResizer', function () {
+		test.test('subrows with hidden columns', function() {
+			var subRows = [ [
+				{ field: 'Id', label: 'ID' },
+				{ field: 'name', label: 'Name' },
+				{ field: 'color', label: 'Color' },
+				{ field: 'custom', label: 'hidden column', hidden: true }
+			], [ { field: "custom", colSpan: 3 } ] ];
+
+			var grid = new (declare([ Grid, ColumnResizer, ColumnHider ]))({
+					subRows: subRows
+				}
+			);
+
+			document.body.appendChild(grid.domNode);
+			grid.startup();
+			grid.renderArray([]);
+		});
+	});
+});

--- a/test/intern/extensions/ColumnResizer.js
+++ b/test/intern/extensions/ColumnResizer.js
@@ -1,10 +1,11 @@
 define([
 	'intern!tdd',
+	'intern/chai!assert',
 	'dojo/_base/declare',
 	'dgrid/Grid',
 	'dgrid/extensions/ColumnHider',
 	'dgrid/extensions/ColumnResizer'
-], function (test, declare, Grid, ColumnHider, ColumnResizer) {
+], function (test, assert, declare, Grid, ColumnHider, ColumnResizer) {
 
 	test.suite('ColumnResizer', function () {
 		test.test('subrows with hidden columns', function() {
@@ -15,14 +16,15 @@ define([
 				{ field: 'custom', label: 'hidden column', hidden: true }
 			], [ { field: "custom", colSpan: 3 } ] ];
 
-			var grid = new (declare([ Grid, ColumnResizer, ColumnHider ]))({
-					subRows: subRows
-				}
-			);
-
-			document.body.appendChild(grid.domNode);
-			grid.startup();
-			grid.renderArray([]);
+			assert.doesNotThrow(function () {
+				var grid = new (declare([ Grid, ColumnResizer, ColumnHider ]))({
+						subRows: subRows
+					}
+				);
+				document.body.appendChild(grid.domNode);
+				grid.startup();
+				grid.renderArray([]);
+			});
 		});
 	});
 });


### PR DESCRIPTION
Added logic to ignore hidden columns when calculating the
number of columns in ColumnResizer, and a corresponding test
case.

Here is the same jsfiddle pointing to this branch instead of 0.4: http://jsfiddle.net/2y1mg8xb/

Fixes #1187