### PR TITLE
Add dimensions to child of rtl test div, and remove browser sniffs

### DIFF
--- a/List.js
+++ b/List.js
@@ -58,15 +58,14 @@ define([
 			isLeft;
 
 		element.className = 'dgrid-scrollbar-measure';
+		div.className = 'dgrid-scrollbar-measure-child';
 		element.setAttribute('dir', 'rtl');
 		element.appendChild(div);
 		document.body.appendChild(element);
 
-		// position: absolute makes IE always report child's offsetLeft as 0,
-		// but it conveniently makes other browsers reset to 0 as base, and all
-		// versions of IE are known to move the scrollbar to the left side for rtl
-		isLeft = !!has('ie') || !!has('trident') || div.offsetLeft >= has('dom-scrollbar-width');
-		cleanupTestElement(element);
+		// Calling has cleans up the element, and trying to clean up again
+		// causes an error in IE8
+		isLeft = div.offsetLeft >= has('dom-scrollbar-width');
 		domConstruct.destroy(div);
 		element.removeAttribute('dir');
 		return isLeft;

--- a/css/base.styl
+++ b/css/base.styl
@@ -154,6 +154,11 @@ html.has-mozilla .dgrid-focus {
 	top: -9999px;
 }
 
+.dgrid-scrollbar-measure-child {
+  width: 10px;
+  height: 10px;
+}
+
 // Styles for auto-height grids; simply add the dgrid-autoheight class
 .dgrid-autoheight {
 	height: auto;

--- a/css/dgrid.css
+++ b/css/dgrid.css
@@ -124,6 +124,10 @@ html.has-mozilla .dgrid-focus {
   position: absolute;
   top: -9999px;
 }
+.dgrid-scrollbar-measure-child {
+  width: 10px;
+  height: 10px;
+}
 .dgrid-autoheight {
   height: auto;
 }


### PR DESCRIPTION
I tested this in IE 8/9/10/11, Edge, Firefox, and Chrome. It works in all of them. The only problem I had was that I couldn't find a browser that doesn't put the scrollbar on the left when dir is set to rtl to test the negative case in.