### PR TITLE
Fix 1215 - fix double nonworking expando

### DIFF
--- a/ColumnSet.js
+++ b/ColumnSet.js
@@ -215,7 +215,7 @@ define([
 
 		columnSets: [],
 
-		createRowCells: function (tag, each, subRows, object) {
+		createRowCells: function (tag, each, subRows, object, options) {
 			var row = domConstruct.create('table', { className: 'dgrid-row-table' });
 			var tbody = domConstruct.create('tbody', null, row);
 			var tr = domConstruct.create('tr', null, tbody);
@@ -229,7 +229,7 @@ define([
 				}, cell);
 				cell.setAttribute(colsetidAttr, i);
 				var subset = getColumnSetSubRows(subRows || this.subRows, i) || this.columnSets[i];
-				cell.appendChild(this.inherited(arguments, [tag, each, subset, object]));
+				cell.appendChild(this.inherited(arguments, [tag, each, subset, object, options]));
 			}
 			return row;
 		},

--- a/Tree.js
+++ b/Tree.js
@@ -288,34 +288,36 @@ define([
 		_configureTreeColumn: function (column) {
 			// summary:
 			//		Adds tree navigation capability to a column.
-			if (!column._isConfiguredTreeColumn) {
-				var originalRenderCell = column.renderCell || this._defaultRenderCell;
-				column._isConfiguredTreeColumn = true;
-				column.renderCell = function (object, value, td, options) {
-					// summary:
-					//		Renders a cell that can be expanded, creating more rows
-
-					var grid = column.grid,
-						level = Number(options && options.queryLevel) + 1,
-						mayHaveChildren = !grid.collection.mayHaveChildren || grid.collection.mayHaveChildren(object),
-						expando, node;
-
-					level = grid._currentLevel = isNaN(level) ? 0 : level;
-					expando = column.renderExpando(level, mayHaveChildren,
-						grid._expanded[grid.collection.getIdentity(object)], object);
-					expando.level = level;
-					expando.mayHaveChildren = mayHaveChildren;
-
-					node = originalRenderCell.call(column, object, value, td, options);
-					if (node && node.nodeType) {
-						td.appendChild(expando);
-						td.appendChild(node);
-					}
-					else {
-						td.insertBefore(expando, td.firstChild);
-					}
-				};
+			if (column._isConfiguredTreeColumn) {
+				return;
 			}
+
+			var originalRenderCell = column.renderCell || this._defaultRenderCell;
+			column._isConfiguredTreeColumn = true;
+			column.renderCell = function (object, value, td, options) {
+				// summary:
+				//		Renders a cell that can be expanded, creating more rows
+
+				var grid = column.grid,
+					level = Number(options && options.queryLevel) + 1,
+					mayHaveChildren = !grid.collection.mayHaveChildren || grid.collection.mayHaveChildren(object),
+					expando, node;
+
+				level = grid._currentLevel = isNaN(level) ? 0 : level;
+				expando = column.renderExpando(level, mayHaveChildren,
+					grid._expanded[grid.collection.getIdentity(object)], object);
+				expando.level = level;
+				expando.mayHaveChildren = mayHaveChildren;
+
+				node = originalRenderCell.call(column, object, value, td, options);
+				if (node && node.nodeType) {
+					td.appendChild(expando);
+					td.appendChild(node);
+				}
+				else {
+					td.insertBefore(expando, td.firstChild);
+				}
+			};
 
 			var clicked; // tracks row that was clicked (for expand dblclick event handling)
 

--- a/test/data/index.json
+++ b/test/data/index.json
@@ -215,6 +215,12 @@
 		"parent": "extensions"
 	},
 	{
+		"name": "CompoundColumns_Tree.html",
+		"url": "extensions/CompoundColumns_Tree.html",
+		"title": "Test Grid with Compound Columns, Column Sets, and Tree",
+		"parent": "extensions"
+	},
+	{
 		"name": "DnD.html",
 		"url": "extensions/DnD.html",
 		"title": "Test Grid DnD",

--- a/test/extensions/CompoundColumns_Tree.html
+++ b/test/extensions/CompoundColumns_Tree.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>Test Grid with Compound Columns, Column Sets, and Tree</title>
+		<meta name="viewport" content="width=570">
+		<style>
+			@import "../../../dojo/resources/dojo.css";
+			@import "../../css/dgrid.css";
+			@import "../../css/skins/claro.css";
+
+			.dgrid {
+				width: 750px;
+				margin: 10px;
+			}
+
+			.dgrid .dgrid-content .dgrid-cell {
+				height: 24px;
+			}
+		</style>
+		<script src="../../../dojo/dojo.js" data-dojo-config="async: true"></script>
+	</head>
+	<body class="claro">
+		<div id="grid"></div>
+
+		<script>
+			require([
+				'dgrid/Tree',
+				'dgrid/ColumnSet',
+				'dgrid/OnDemandGrid',
+				'dgrid/extensions/CompoundColumns',
+				'dgrid/test/data/createHierarchicalStore',
+				'dgrid/test/data/hierarchicalCountryData'
+			], function (Tree, ColumnSet, OnDemandGrid, CompoundColumns, createHierarchicalStore, data) {
+					var CompoundTree = OnDemandGrid.createSubclass([ Tree, CompoundColumns, ColumnSet ]);
+					var store = createHierarchicalStore({ data: data });
+
+
+					var columnSets = [
+						[
+							[
+								{
+									field: 'name',
+									label: 'Name',
+									renderExpando: true
+								}
+							]
+						],
+						[
+							[
+								{
+									label: 'Information',
+									children: [
+										{
+											field: 'type',
+											label: 'Type'
+										}, {
+											field: 'population',
+											label: 'Population'
+										}
+									]
+								}
+							]
+						]
+					];
+
+					window.grid = new CompoundTree({
+						columnSets: columnSets,
+						collection: store.getRootCollection()
+					}, 'grid');
+				});
+		</script>
+	</body>
+</html>

--- a/test/intern/all.js
+++ b/test/intern/all.js
@@ -20,5 +20,6 @@ define([
 	'intern/node_modules/dojo/has!host-browser?./mixins/Selector',
 	'intern/node_modules/dojo/has!host-browser?./mixins/Tree',
 	'intern/node_modules/dojo/has!host-browser?./mixins/Tree-expand-promise',
-	'intern/node_modules/dojo/has!host-browser?./mixins/Tree-additional-filter'
+	'intern/node_modules/dojo/has!host-browser?./mixins/Tree-additional-filter',
+	'intern/node_modules/dojo/has!host-browser?./mixins/Tree-indent'
 ], function () {});

--- a/test/intern/functional/Tree.js
+++ b/test/intern/functional/Tree.js
@@ -69,4 +69,19 @@ define([
 		test.test('expand/collapse: click on expando node', createExpandTest('.dgrid-expando-icon', 'click'));
 		test.test('expand/collapse: double-click on cell node', createExpandTest('.dgrid-column-0', 'doubleClick'));
 	});
+
+	test.suite('dgrid/Tree functional tests with CompoundColumns', function () {
+
+		test.before(function () {
+			var remote = this.remote;
+
+			return remote.get(require.toUrl('./TreeCompound.html'))
+				.then(pollUntil(function () {
+					return window.ready;
+				}, null, 5000));
+		});
+
+		test.test('expand/collapse: click on expando node', createExpandTest('.dgrid-expando-icon', 'click'));
+		test.test('expand/collapse: double-click on cell node', createExpandTest('.dgrid-column-set-0', 'doubleClick'));
+	});
 });

--- a/test/intern/functional/TreeCompound.html
+++ b/test/intern/functional/TreeCompound.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test dgrid/Tree module with dgrid/extensions/CompoundColumns</title>
+
+<style>
+	@import "../../../../dojo/resources/dojo.css";
+	@import "../../../css/dgrid.css";
+	@import "../../../css/skins/claro.css";
+
+	.dgrid {
+		width: 700px;
+		margin: 10px;
+	}
+
+	.dgrid .dgrid-content .dgrid-cell {
+		height: 24px;
+	}
+
+	#treeGrid .field-type {
+		width: 5em;
+	}
+</style>
+</head>
+
+<body class="claro">
+<div id="treeGrid"></div>
+
+<script src="../../../../dojo/dojo.js" data-dojo-config="async: true"></script>
+
+<script>
+var treeGrid;
+var ready;
+
+require([
+	'dgrid/OnDemandGrid',
+	'dgrid/Tree',
+	'dgrid/ColumnSet',
+	'dgrid/extensions/CompoundColumns',
+	'dgrid/test/data/createHierarchicalStore',
+	'dgrid/test/data/hierarchicalCountryData'
+], function (OnDemandGrid, Tree, ColumnSet, CompoundColumns,
+			 createHierarchicalStore, hierarchicalCountryData) {
+
+	var testCountryStore = createHierarchicalStore({data: hierarchicalCountryData});
+
+	treeGrid = new (OnDemandGrid.createSubclass([ Tree, CompoundColumns, ColumnSet ]))({
+		sort: 'id',
+		collection: testCountryStore,
+		columnSets: [
+			[
+				[
+					{
+						renderExpando: true,
+						label: 'Name',
+						field: 'name',
+						sortable: false
+					}
+				]
+			],
+			[
+				[
+					{
+						label: 'Info',
+						sortable: false,
+						children: [
+							{
+								label: 'Type',
+								field: 'type',
+								sortable: false
+							},
+							{
+								label: 'Population',
+								field: 'population'
+							},
+							{
+								label: 'Timezone',
+								field: 'timezone'
+							}
+						]
+					}
+				]
+			]
+		]
+	}, 'treeGrid');
+
+	ready = true;
+});
+</script>
+</body>
+</html>

--- a/test/intern/mixins/Tree-indent.js
+++ b/test/intern/mixins/Tree-indent.js
@@ -1,0 +1,121 @@
+define([
+	'intern!tdd',
+	'intern/chai!assert',
+	'dgrid/ColumnSet',
+	'dgrid/OnDemandGrid',
+	'dgrid/Tree',
+	'dgrid/extensions/CompoundColumns',
+	'dgrid/util/has-css3',
+	'dojo/_base/declare',
+	'dojo/query',
+	'dgrid/test/data/createHierarchicalStore',
+	'dgrid/test/data/hierarchicalCountryData',
+	'../rowExpand',
+	'../addCss!'
+], function (test, assert, ColumnSet, OnDemandGrid, Tree, CompoundColumns, has, declare, query,
+			 createHierarchicalStore, data, rowExpand) {
+
+	test.suite('tree indent', function () {
+
+		var grid;
+		var treeIndentWidth = 20;
+
+		function testIndentWidth(id, level) {
+			var row = grid.row(id);
+			assert.ok(row.element, 'Expected child row exists');
+			query('.dgrid-expando-icon', row.element).forEach(function (element) {
+				assert.strictEqual(element.style.marginLeft, treeIndentWidth * level + 'px');
+			});
+		}
+
+		test.afterEach(function () {
+			if (grid) {
+				grid.destroy();
+				grid = null;
+			}
+		});
+
+		function level1Test() {
+			return rowExpand(grid, 'AF').then(function () {
+				testIndentWidth('EG', 1);
+			});
+		}
+
+		function level2Test() {
+			return rowExpand(grid, 'AF').then(function () {
+				return rowExpand(grid, 'EG');
+			}).then(function () {
+				testIndentWidth('Cairo', 2);
+			});
+		}
+
+		test.suite('OnDemandGrid + tree', function () {
+			test.beforeEach(function () {
+				grid = new (declare([OnDemandGrid, Tree]))({
+					collection: createHierarchicalStore({data: data}),
+					treeIndentWidth: treeIndentWidth,
+					columns: [
+						{
+							field: 'name',
+							label: 'Name',
+							renderExpando: true
+						},
+						{
+							field: 'type',
+							label: 'Type'
+						}, {
+							field: 'population',
+							label: 'Population'
+						}
+					]
+				});
+				document.body.appendChild(grid.domNode);
+				grid.startup();
+			});
+
+			test.test('level 1', level1Test);
+			test.test('level 2', level2Test);
+		});
+
+		test.suite('OnDemandGrid + tree + compound columns + column sets', function () {
+			test.beforeEach(function () {
+				grid = new (declare([OnDemandGrid, Tree, CompoundColumns, ColumnSet]))({
+					collection: createHierarchicalStore({data: data}),
+					treeIndentWidth: treeIndentWidth,
+					columnSets: [
+						[
+							[
+								{
+									field: 'name',
+									label: 'Name',
+									renderExpando: true
+								}
+							]
+						],
+						[
+							[
+								{
+									label: 'Information',
+									children: [
+										{
+											field: 'type',
+											label: 'Type'
+										}, {
+											field: 'population',
+											label: 'Population'
+										}
+									]
+								}
+							]
+						]
+					]
+				});
+				document.body.appendChild(grid.domNode);
+				grid.startup();
+			});
+
+			test.test('level 1', level1Test);
+			test.test('level 2', level2Test);
+		});
+	});
+});

--- a/test/intern/mixins/Tree-indent.js
+++ b/test/intern/mixins/Tree-indent.js
@@ -5,14 +5,13 @@ define([
 	'dgrid/OnDemandGrid',
 	'dgrid/Tree',
 	'dgrid/extensions/CompoundColumns',
-	'dgrid/util/has-css3',
 	'dojo/_base/declare',
 	'dojo/query',
 	'dgrid/test/data/createHierarchicalStore',
 	'dgrid/test/data/hierarchicalCountryData',
 	'../rowExpand',
 	'../addCss!'
-], function (test, assert, ColumnSet, OnDemandGrid, Tree, CompoundColumns, has, declare, query,
+], function (test, assert, ColumnSet, OnDemandGrid, Tree, CompoundColumns, declare, query,
 			 createHierarchicalStore, data, rowExpand) {
 
 	test.suite('tree indent', function () {

--- a/test/intern/mixins/Tree.js
+++ b/test/intern/mixins/Tree.js
@@ -4,7 +4,6 @@ define([
 	'dgrid/OnDemandGrid',
 	'dgrid/Editor',
 	'dgrid/Tree',
-	'dgrid/util/has-css3',
 	'dgrid/util/misc',
 	'dojo/_base/declare',
 	'dojo/_base/lang',
@@ -16,13 +15,13 @@ define([
 	'dojo/on',
 	'dojo/query',
 	'dgrid/test/data/createHierarchicalStore',
+	'../rowExpand',
 	'../addCss!'
-], function (test, assert, OnDemandGrid, Editor, Tree, has, miscUtil, declare, lang, aspect, Deferred,
-		domClass, domConstruct, domStyle, on, query, createHierarchicalStore) {
+], function (test, assert, OnDemandGrid, Editor, Tree, miscUtil, declare, lang, aspect, Deferred,
+		domClass, domConstruct, domStyle, on, query, createHierarchicalStore, rowExpand) {
 
 	var grid,
-		testDelay = 15,
-		hasTransitionEnd = has('transitionend');
+		testDelay = 15;
 
 	function createGrid(options, setStoreAfterStartup) {
 		var data = [],
@@ -106,25 +105,6 @@ define([
 		return dfd.promise;
 	}
 
-	// Define a function returning a promise resolving once children are expanded.
-	// On browsers which support CSS3 transitions, this occurs when transitionend fires;
-	// otherwise it occurs immediately.
-	var expand = hasTransitionEnd ? function (id) {
-		var dfd = new Deferred();
-
-		on.once(grid, hasTransitionEnd, function () {
-			dfd.resolve();
-		});
-
-		grid.expand(id);
-		return dfd.promise;
-	} : function (id) {
-		var dfd = new Deferred();
-		grid.expand(id);
-		dfd.resolve();
-		return dfd.promise;
-	};
-
 	function scrollToEnd() {
 		var dfd = new Deferred(),
 			handle;
@@ -157,7 +137,7 @@ define([
 			test.afterEach(destroyGrid);
 
 			test.test('expand first row', function () {
-				return expand(0)
+				return rowExpand(grid, 0)
 					.then(function () {
 						testRowExists('0:0');
 						testRowExists('0:99', false);
@@ -165,7 +145,7 @@ define([
 			});
 
 			test.test('expand last row', function () {
-				return expand(4).then(function () {
+				return rowExpand(grid, 4).then(function () {
 					testRowExists('4:0');
 					testRowExists('4:99', false);
 				});
@@ -179,7 +159,7 @@ define([
 			test.afterEach(destroyGrid);
 
 			test.test('expand first row', function () {
-				return expand(0)
+				return rowExpand(grid, 0)
 					.then(function () {
 						testRowExists('0:0');
 						testRowExists('0:99', false);
@@ -187,7 +167,7 @@ define([
 			});
 
 			test.test('expand first row + scroll to bottom', function () {
-				return expand(0)
+				return rowExpand(grid, 0)
 					.then(scrollToEnd)
 					.then(function () {
 						testRowExists('0:0');
@@ -196,14 +176,14 @@ define([
 			});
 
 			test.test('expand last row', function () {
-				return expand(4).then(function () {
+				return rowExpand(grid, 4).then(function () {
 					testRowExists('4:0');
 					testRowExists('4:99', false);
 				});
 			});
 
 			test.test('expand last row + scroll to bottom', function () {
-				return expand(4)
+				return rowExpand(grid, 4)
 					.then(scrollToEnd)
 					.then(function () {
 						testRowExists('4:0');
@@ -212,10 +192,10 @@ define([
 			});
 
 			test.test('expand first and last rows + scroll to bottom', function () {
-				return expand(0)
+				return rowExpand(grid, 0)
 					.then(scrollToEnd)
 					.then(function () {
-						return expand(4);
+						return rowExpand(grid, 4);
 					})
 					.then(scrollToEnd)
 					.then(function () {
@@ -401,7 +381,7 @@ define([
 
 				assert.strictEqual(countRowExpandos(), 1, 'Each parent row should have one expando icon');
 				grid.set('columns', grid.get('columns'));
-				assert.strictEqual(countRowExpandos(), 1,'Each parent row should still have only one expando icon');
+				assert.strictEqual(countRowExpandos(), 1, 'Each parent row should still have only one expando icon');
 			});
 		});
 
@@ -414,7 +394,7 @@ define([
 			test.afterEach(destroyGrid);
 
 			test.test('expand first row', function () {
-				return expand(0)
+				return rowExpand(grid, 0)
 					.then(function () {
 						testRowExists('0:0');
 						var row = grid.row('0:0').element;
@@ -429,7 +409,7 @@ define([
 			test.afterEach(destroyGrid);
 
 			test.test('child modification', function () {
-				return expand(0).then(function () {
+				return rowExpand(grid, 0).then(function () {
 					testRowExists('0:0');
 					assert.doesNotThrow(function () {
 						grid.collection.putSync({
@@ -442,7 +422,7 @@ define([
 			});
 
 			test.test('child modification after parent when expanded', function () {
-				return expand(0).then(function () {
+				return rowExpand(grid, 0).then(function () {
 					grid.collection.putSync({
 						id: '0',
 						value: 'Modified'
@@ -462,8 +442,8 @@ define([
 				});
 			});
 
-			test.test('collapse items removed from store', function() {
-				return expand(0).then(function () {
+			test.test('collapse items removed from store', function () {
+				return rowExpand(grid, 0).then(function () {
 					assert.isTrue(domClass.contains(grid.row(0).element, 'dgrid-row-expanded'),
 						'Should have expanded class');
 					var item = grid.collection.getSync(0);
@@ -495,7 +475,7 @@ define([
 			});
 
 			test.test('child add', function () {
-				return expand(0).then(function () {
+				return rowExpand(grid, 0).then(function () {
 					testRowExists('0:0');
 					grid.collection.add({
 						id: '0:0.5',
@@ -507,7 +487,7 @@ define([
 			});
 
 			test.test('child put', function () {
-				return expand(0).then(function () {
+				return rowExpand(grid, 0).then(function () {
 					var calls = 0;
 
 					handles.push(aspect.before(grid, 'removeRow', function () {
@@ -529,32 +509,10 @@ define([
 			});
 
 			test.test('child remove', function () {
-				return expand(0).then(function () {
+				return rowExpand(grid, 0).then(function () {
 					testRowExists('0:0');
 					grid.collection.remove('0:0');
 					testRowExists('0:0');
-				});
-			});
-		});
-
-		test.suite('treeIndentWidth', function () {
-			var treeIndentWidth = 20;
-			test.beforeEach(function () {
-				createGrid({
-					gridOptions: { treeIndentWidth: treeIndentWidth }
-				});
-				return wait();
-			});
-
-			test.afterEach(destroyGrid);
-
-			test.test('treeIndentWidth override', function () {
-				return expand(0).then(function () {
-					var row = grid.row('0:0');
-					assert.ok(row, 'Expected child row exists');
-					query('.dgrid-expando-icon', row.element).forEach(function (element) {
-						assert.strictEqual(element.style.marginLeft, treeIndentWidth + 'px');
-					});
 				});
 			});
 		});

--- a/test/intern/rowExpand.js
+++ b/test/intern/rowExpand.js
@@ -1,0 +1,25 @@
+define([
+	'dojo/Deferred',
+	'dojo/on',
+	'dgrid/util/has-css3'
+], function (Deferred, on, has) {
+	// Define a function returning a promise resolving once children are expanded.
+	// On browsers which support CSS3 transitions, this occurs when transitionend fires;
+	// otherwise it occurs immediately.
+	var hasTransitionEnd = has('transitionend');
+	return hasTransitionEnd ? function (grid, id) {
+		var dfd = new Deferred();
+
+		on.once(grid, hasTransitionEnd, function () {
+			dfd.resolve();
+		});
+
+		grid.expand(id);
+		return dfd.promise;
+	} : function (grid, id) {
+		var dfd = new Deferred();
+		grid.expand(id);
+		dfd.resolve();
+		return dfd.promise;
+	};
+});


### PR DESCRIPTION
The double expando icon problem was fixed in 0f67fa108b3952069ab36dd0cd0ad7fcbddf4a8e.  That fix avoided rendering the icon twice but did nothing to avoid registering multiple event handlers.  With two event handlers, the first would expand the clicked-on row and the second one would collapse it (`expand()` is a toggle if the second parameter is not passed).