### PR TITLE
Fix #1241 - support proper child row drag-and-drop.

### DIFF
--- a/extensions/DnD.js
+++ b/extensions/DnD.js
@@ -249,14 +249,18 @@ define([
 
 			// Make the grid's content a DnD source/target.
 			var Source = this.dndConstructor || GridDnDSource;
-			this.dndSource = new Source(
-				this.bodyNode,
-				lang.mixin(this.dndParams, {
-					// add cross-reference to grid for potential use in inter-grid drop logic
-					grid: this,
-					dropParent: this.contentNode
-				})
-			);
+
+			var dndParams = lang.mixin(this.dndParams, {
+				// add cross-reference to grid for potential use in inter-grid drop logic
+				grid: this,
+				dropParent: this.contentNode
+			});
+			if (typeof this.expand === 'function') {
+				// If the Tree mixin is being used, allowNested needs to be set to true for DnD to work properly
+				// with the child rows.  Without it, child rows will always move to the last child position.
+				dndParams.allowNested = true;
+			}
+			this.dndSource = new Source(this.bodyNode, dndParams);
 
 			// Set up select/deselect handlers to maintain references, in case selected
 			// rows are scrolled out of view and unrendered, but then dragged.

--- a/test/data/index.json
+++ b/test/data/index.json
@@ -233,6 +233,12 @@
 		"parent": "extensions"
 	},
 	{
+		"name": "DnD_Tree_children.html",
+		"url": "extensions/DnD_Tree_children.html",
+		"title": "Test dragging parent and child rows",
+		"parent": "extensions"
+	},
+	{
 		"name": "DnD_error.html",
 		"url": "extensions/DnD_error.html",
 		"title": "Test Grid DnD on stores returning rejected promises",

--- a/test/extensions/DnD_Tree_children.html
+++ b/test/extensions/DnD_Tree_children.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Test dragging parent and child rows</title>
+		<style>
+			@import "../../../dojo/resources/dojo.css";
+			@import "../../css/dgrid.css";
+
+			.dgrid {
+				width: 700px;
+				margin: 10px;
+			}
+		</style>
+		<script src="../../../dojo/dojo.js"
+				data-dojo-config="async: true"></script>
+	</head>
+	<body class='claro'>
+		<div>Test dragging the parent rows and the child rows within this single grid.</div>
+		<div id='treeGrid'></div>
+		<script>
+			require([
+				'dgrid/OnDemandGrid', 'dgrid/Tree', 'dgrid/extensions/DnD',
+				'dgrid/test/data/createHierarchicalStore', 'dgrid/test/data/hierarchicalCountryData'
+			], function (OnDemandGrid, Tree, DnD, createHierarchicalStore, hierarchicalCountryData) {
+				var store = createHierarchicalStore({data: hierarchicalCountryData});
+				var grid = new (OnDemandGrid.createSubclass([Tree, DnD]))({
+					collection: store,
+					columns: [
+						{label: "Name", field:"name", sortable: false, renderExpando: true},
+						{label:"Type", field:"type", sortable: false},
+						{label:"Population", field:"population"},
+						{label:"Timezone", field:"timezone"}
+					]
+				}, 'treeGrid');
+			});
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Add code to dgrid/extensions/DnD to look for us of the dgrid/Tree mixin.  If Tree is being used, set `allowNested` to true which allows the Dojo DnD code to property identify the child row container as a valid drop target.