### PR TITLE
Update the Tree mixin to handle resetting columns to the same current configuration

### DIFF
--- a/Tree.js
+++ b/Tree.js
@@ -289,84 +289,84 @@ define([
 		_configureTreeColumn: function (column) {
 			// summary:
 			//		Adds tree navigation capability to a column.
-			if (column._isConfiguredTreeColumn) {
-				return;
-			}
-
-			var originalRenderCell = column.renderCell || this._defaultRenderCell;
-			column._isConfiguredTreeColumn = true;
-			column.renderCell = function (object, value, td, options) {
-				// summary:
-				//		Renders a cell that can be expanded, creating more rows
-
-				var grid = column.grid,
-					level = Number(options && options.queryLevel) + 1,
-					mayHaveChildren = !grid.collection.mayHaveChildren || grid.collection.mayHaveChildren(object),
-					expando, node;
-
-				level = grid._currentLevel = isNaN(level) ? 0 : level;
-				expando = column.renderExpando(level, mayHaveChildren,
-					grid._expanded[grid.collection.getIdentity(object)], object);
-				expando.level = level;
-				expando.mayHaveChildren = mayHaveChildren;
-
-				node = originalRenderCell.call(column, object, value, td, options);
-				if (node && node.nodeType) {
-					td.appendChild(expando);
-					td.appendChild(node);
-				}
-				else {
-					td.insertBefore(expando, td.firstChild);
-				}
-			};
-
-			var clicked; // tracks row that was clicked (for expand dblclick event handling)
-
-			this._treeColumn = column;
 
 			var grid = this,
 				colSelector = '.dgrid-content .dgrid-column-' + column.id;
 
-			if (typeof column.renderExpando !== 'function') {
-				column.renderExpando = this._defaultRenderExpando;
+			this._treeColumn = column;
+			if (!column._isConfiguredTreeColumn) {
+				var originalRenderCell = column.renderCell || this._defaultRenderCell;
+				column._isConfiguredTreeColumn = true;
+				column.renderCell = function (object, value, td, options) {
+					// summary:
+					//		Renders a cell that can be expanded, creating more rows
+
+					var grid = column.grid,
+						level = Number(options && options.queryLevel) + 1,
+						mayHaveChildren = !grid.collection.mayHaveChildren || grid.collection.mayHaveChildren(object),
+						expando, node;
+
+					level = grid._currentLevel = isNaN(level) ? 0 : level;
+					expando = column.renderExpando(level, mayHaveChildren,
+						grid._expanded[grid.collection.getIdentity(object)], object);
+					expando.level = level;
+					expando.mayHaveChildren = mayHaveChildren;
+
+					node = originalRenderCell.call(column, object, value, td, options);
+					if (node && node.nodeType) {
+						td.appendChild(expando);
+						td.appendChild(node);
+					}
+					else {
+						td.insertBefore(expando, td.firstChild);
+					}
+				};
+
+				var clicked; // tracks row that was clicked (for expand dblclick event handling)
+
+				if (typeof column.renderExpando !== 'function') {
+					column.renderExpando = this._defaultRenderExpando;
+				}
 			}
 
-			// Set up the event listener once and use event delegation for better memory use.
-			this._treeColumnListeners.push(this.on(column.expandOn ||
+			var treeColumnListeners = this._treeColumnListeners;
+			if (treeColumnListeners.length === 0) {
+				// Set up the event listener once and use event delegation for better memory use.
+				this._treeColumnListeners.push(this.on(column.expandOn ||
 					'.dgrid-expando-icon:click,' + colSelector + ':dblclick,' + colSelector + ':keydown',
-				function (event) {
-					var row = grid.row(event);
-					if ((!grid.collection.mayHaveChildren || grid.collection.mayHaveChildren(row.data)) &&
-						(event.type !== 'keydown' || event.keyCode === 32) && !(event.type === 'dblclick' &&
+					function (event) {
+						var row = grid.row(event);
+						if ((!grid.collection.mayHaveChildren || grid.collection.mayHaveChildren(row.data)) &&
+							(event.type !== 'keydown' || event.keyCode === 32) && !(event.type === 'dblclick' &&
 							clicked && clicked.count > 1 && row.id === clicked.id &&
 							event.target.className.indexOf('dgrid-expando-icon') > -1)) {
-						grid.expand(row);
-					}
-
-					// If the expando icon was clicked, update clicked object to prevent
-					// potential over-triggering on dblclick (all tested browsers but IE < 9).
-					if (event.target.className.indexOf('dgrid-expando-icon') > -1) {
-						if (clicked && clicked.id === grid.row(event).id) {
-							clicked.count++;
+							grid.expand(row);
 						}
-						else {
-							clicked = {
-								id: grid.row(event).id,
-								count: 1
-							};
-						}
-					}
-				})
-			);
 
-			if (has('touch')) {
-				// Also listen on double-taps of the cell.
-				this._treeColumnListeners.push(this.on(touchUtil.selector(colSelector, touchUtil.dbltap),
-					function () {
-						grid.expand(this);
-					}));
+						// If the expando icon was clicked, update clicked object to prevent
+						// potential over-triggering on dblclick (all tested browsers but IE < 9).
+						if (event.target.className.indexOf('dgrid-expando-icon') > -1) {
+							if (clicked && clicked.id === grid.row(event).id) {
+								clicked.count++;
+							}
+							else {
+								clicked = {
+									id: grid.row(event).id,
+									count: 1
+								};
+							}
+						}
+					})
+				);
+
+				if (has('touch')) {
+					// Also listen on double-taps of the cell.
+					this._treeColumnListeners.push(this.on(touchUtil.selector(colSelector, touchUtil.dbltap),
+						function () {
+							grid.expand(this);
+						}));
+				}
 			}
-
 		},
 
 		_defaultRenderExpando: function (level, hasChildren, expanded) {

--- a/Tree.js
+++ b/Tree.js
@@ -290,8 +290,9 @@ define([
 			// summary:
 			//		Adds tree navigation capability to a column.
 
-			var grid = this,
-				colSelector = '.dgrid-content .dgrid-column-' + column.id;
+			var grid = this;
+			var colSelector = '.dgrid-content .dgrid-column-' + column.id;
+			var clicked; // tracks row that was clicked (for expand dblclick event handling)
 
 			this._treeColumn = column;
 			if (!column._isConfiguredTreeColumn) {
@@ -321,8 +322,6 @@ define([
 						td.insertBefore(expando, td.firstChild);
 					}
 				};
-
-				var clicked; // tracks row that was clicked (for expand dblclick event handling)
 
 				if (typeof column.renderExpando !== 'function') {
 					column.renderExpando = this._defaultRenderExpando;

--- a/test/extensions/CompoundColumns_Tree.html
+++ b/test/extensions/CompoundColumns_Tree.html
@@ -22,6 +22,7 @@
 	</head>
 	<body class="claro">
 		<div id="grid"></div>
+		<button id="setColumnsButton">Set Columns</button>
 
 		<script>
 			require([
@@ -30,8 +31,9 @@
 				'dgrid/OnDemandGrid',
 				'dgrid/extensions/CompoundColumns',
 				'dgrid/test/data/createHierarchicalStore',
-				'dgrid/test/data/hierarchicalCountryData'
-			], function (Tree, ColumnSet, OnDemandGrid, CompoundColumns, createHierarchicalStore, data) {
+				'dgrid/test/data/hierarchicalCountryData',
+				'dojo/on'
+			], function (Tree, ColumnSet, OnDemandGrid, CompoundColumns, createHierarchicalStore, data, on) {
 					var CompoundTree = OnDemandGrid.createSubclass([ Tree, CompoundColumns, ColumnSet ]);
 					var store = createHierarchicalStore({ data: data });
 
@@ -63,10 +65,14 @@
 						]
 					];
 
-					window.grid = new CompoundTree({
+					var grid = new CompoundTree({
 						columnSets: columnSets,
 						collection: store.getRootCollection()
 					}, 'grid');
+
+					on(document.getElementById('setColumnsButton'), 'click', function () {
+						grid.set('columns', grid.get('columns'));
+					});
 				});
 		</script>
 	</body>

--- a/test/intern/functional/Tree.js
+++ b/test/intern/functional/Tree.js
@@ -84,4 +84,25 @@ define([
 		test.test('expand/collapse: click on expando node', createExpandTest('.dgrid-expando-icon', 'click'));
 		test.test('expand/collapse: double-click on cell node', createExpandTest('.dgrid-column-set-0', 'doubleClick'));
 	});
+
+	test.suite('dgrid/Tree functional tests with CompoundColumns after column reset', function () {
+
+		test.before(function () {
+			var remote = this.remote;
+
+			return remote.get(require.toUrl('./TreeCompound.html'))
+				.then(pollUntil(function () {
+					return window.ready;
+				}, null, 5000))
+				.then(function () {
+					return remote.execute(function () {
+						/* global treeGrid */
+						treeGrid.set('columns', treeGrid.get('columns'));
+					});
+				});
+		});
+
+		test.test('expand/collapse: click on expando node', createExpandTest('.dgrid-expando-icon', 'click'));
+		test.test('expand/collapse: double-click on cell node', createExpandTest('.dgrid-column-set-0', 'doubleClick'));
+	});
 });


### PR DESCRIPTION
The code now allows Tree#_configColumns to configure the expand-o node and the event handlers separately.

I tried placing a call to _destroyColumns in ColumnSets#configStructure before the call to this.inherited(arguments) but that does not work in all cases.  ColumnsSets does not always cause Tree#_configColumns to be called twice.  It depends on how the subrows array is populated by the other mixins.  The ordering of the mixins can make a different too.

I added a button to the compound columns manual test to test the error condition and I added functional tests that cover the error condition as well.