### PR TITLE
Fix #1260: break up refreshCell logic to allow Tee to retain level

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -335,17 +335,31 @@ define([
 		},
 
 		refreshCell: function (cell) {
-			var value = cell.column.get ? cell.column.get(cell.row.data) : cell.row.data[cell.column.field];
-			var editor = this._editorInstances[cell.column.id] || cell.element.widget;
+			var column = cell.column;
+			var value = column.get ? column.get(cell.row.data) : cell.row.data[column.field];
+
+			var editor;
+
+			if (column.editor) {
+				if (cell.column.editOn && this._activeCell === cell.element) {
+					editor = this._editorInstances[cell.column.id];
+				}
+				else if (!cell.column.editOn) {
+					editor = cell.element.widget || cell.element.input;
+				}
+			}
 
 			if (editor) {
-				editor.set('value', value);
-			}
-			else {
-				this._updateInputValue(cell.element.input, value);
+				if (editor.domNode) {
+					editor.set('value', value);
+				}
+				else {
+					this._updateInputValue(editor, value);
+				}
+				return (new Deferred()).resolve();
 			}
 
-			return (new Deferred()).resolve();
+			return this.inherited(arguments);
 		},
 
 		_showEditor: function (cmp, column, cellElement, value) {

--- a/Editor.js
+++ b/Editor.js
@@ -334,14 +334,18 @@ define([
 			return null;
 		},
 
-		refreshCell: function(cell) {
-			var rowElementId = cell.row.element.id;
-			var columnId = cell.column.id;
-			if (this._editorCellListeners[rowElementId] && this._editorCellListeners[rowElementId][columnId]) {
-				this._editorCellListeners[rowElementId][columnId].remove();
-				this._editorCellListeners[rowElementId][columnId] = null;
+		refreshCell: function (cell) {
+			var value = cell.column.get ? cell.column.get(cell.row.data) : cell.row.data[cell.column.field];
+			var editor = this._editorInstances[cell.column.id] || cell.element.widget;
+
+			if (editor) {
+				editor.set('value', value);
 			}
-			return this.inherited(arguments);
+			else {
+				this._updateInputValue(cell.element.input, value);
+			}
+
+			return (new Deferred()).resolve();
 		},
 
 		_showEditor: function (cmp, column, cellElement, value) {

--- a/Selector.js
+++ b/Selector.js
@@ -37,7 +37,7 @@ define([
 			var grid = column.grid;
 
 			domClass.add(cell, 'dgrid-selector');
-			return cell.input || (cell.input = domConstruct.create('input', {
+			return (cell.input = domConstruct.create('input', {
 				'aria-checked': selected,
 				checked: selected,
 				disabled: !grid.allowSelect(grid.row(object)),

--- a/Selector.js
+++ b/Selector.js
@@ -2,10 +2,11 @@ define([
 	'dojo/_base/declare',
 	'dojo/_base/lang',
 	'dojo/_base/sniff',
+	'dojo/Deferred',
 	'dojo/dom-construct',
 	'dojo/dom-class',
 	'./Selection'
-], function (declare, lang, has, domConstruct, domClass, Selection) {
+], function (declare, lang, has, Deferred, domConstruct, domClass, Selection) {
 
 	return declare(Selection, {
 		// summary:
@@ -31,6 +32,15 @@ define([
 			// Register listeners to the select and deselect events to change the input checked value
 			this.on('dgrid-select', lang.hitch(this, '_changeSelectorInput', true));
 			this.on('dgrid-deselect', lang.hitch(this, '_changeSelectorInput', false));
+		},
+
+		refreshCell: function (cell) {
+			// columns created by the Selector module should not be refreshed
+			if (cell.column.selector) {
+				return (new Deferred()).resolve();
+			} else {
+				return this.inherited(arguments);
+			}
 		},
 
 		_defaultRenderSelectorInput: function (column, selected, cell, object) {

--- a/Tree.js
+++ b/Tree.js
@@ -257,6 +257,16 @@ define([
 			this.inherited(arguments);
 		},
 
+		_refreshCellFromItem: function (cell, item) {
+			if (!cell.column.renderExpando) {
+				return this.inherited(arguments);
+			}
+
+			this.inherited(arguments, [ cell, item, {
+				queryLevel: querySelector('.dgrid-expando-icon', cell.element)[0].level - 1
+			}]);
+		},
+
 		cleanup: function () {
 			this.inherited(arguments);
 

--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -230,11 +230,6 @@ define([
 				throw new Error('refreshCell requires a Grid with a collection.');
 			}
 
-			// columns created by the Selector module should not be refreshed
-			if (cell.column.selector) {
-				return (new Deferred()).resolve();
-			}
-
 			this.inherited(arguments);
 			return this.collection.get(cell.row.id).then(lang.hitch(this, '_refreshCellFromItem', cell));
 		},

--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -226,28 +226,27 @@ define([
 		},
 
 		refreshCell: function (cell) {
-			this.inherited(arguments);
-			var row = cell.row;
-			var self = this;
-
 			if (!this.collection || !this._createBodyRowCell) {
 				throw new Error('refreshCell requires a Grid with a collection.');
 			}
 
-			return this.collection.get(row.id).then(function (item) {
-				var cellElement = cell.element;
-				if (cellElement.widget) {
-					cellElement.widget.destroyRecursive();
-				}
-				domConstruct.empty(cellElement);
+			this.inherited(arguments);
+			return this.collection.get(cell.row.id).then(lang.hitch(this, '_refreshCellFromItem', cell));
+		},
 
-				var dirtyItem = self.dirty && self.dirty[row.id];
-				if (dirtyItem) {
-					item = lang.delegate(item, dirtyItem);
-				}
+		_refreshCellFromItem: function (cell, item, options) {
+			var cellElement = cell.element;
+			if (cellElement.widget) {
+				cellElement.widget.destroyRecursive();
+			}
+			domConstruct.empty(cellElement);
 
-				self._createBodyRowCell(cellElement, cell.column, item);
-			});
+			var dirtyItem = this.dirty && this.dirty[cell.row.id];
+			if (dirtyItem) {
+				item = lang.delegate(item, dirtyItem);
+			}
+
+			this._createBodyRowCell(cellElement, cell.column, item, options);
 		},
 
 		renderArray: function () {

--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -230,6 +230,11 @@ define([
 				throw new Error('refreshCell requires a Grid with a collection.');
 			}
 
+			// columns created by the Selector module should not be refreshed
+			if (cell.column.selector) {
+				return (new Deferred()).resolve();
+			}
+
 			this.inherited(arguments);
 			return this.collection.get(cell.row.id).then(lang.hitch(this, '_refreshCellFromItem', cell));
 		},

--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -236,9 +236,7 @@ define([
 
 		_refreshCellFromItem: function (cell, item, options) {
 			var cellElement = cell.element;
-			if (cellElement.widget) {
-				cellElement.widget.destroyRecursive();
-			}
+
 			domConstruct.empty(cellElement);
 
 			var dirtyItem = this.dirty && this.dirty[cell.row.id];

--- a/test/data/testTopHeavyHierarchicalStore.js
+++ b/test/data/testTopHeavyHierarchicalStore.js
@@ -1,8 +1,9 @@
 define([
+	'dstore/Tree',
 	'./createSyncStore',
 	'./stateData',
 	'dojo/_base/array'
-], function (createSyncStore, stateData, arrayUtil) {
+], function (Tree, createSyncStore, stateData, arrayUtil) {
 
 	var nextId = 0;
 	var topHeavyData = arrayUtil.map(stateData.items, function (state) {
@@ -10,25 +11,22 @@ define([
 			id: nextId++,
 			abbreviation: state.abbreviation,
 			name: state.name,
-			children: [{
-				id: nextId++,
-				abbreviation: 'US',
-				name: 'United States of America'
-			}]
+			hasChildren: true,
+			parent: null
 		};
 	});
 
 	// Store with few children and many parents to exhibit any
 	// issues due to bugs related to total disregarding level
-	return createSyncStore({
-		data: topHeavyData,
-		getChildren: function (parent) {
-			return createSyncStore({
-				data: parent.children
-			});
-		},
-		mayHaveChildren: function (parent) {
-			return !!parent.children;
-		}
+	arrayUtil.forEach(topHeavyData, function (state) {
+		topHeavyData.push({
+			id: nextId++,
+			abbreviation: 'US',
+			name: 'United States of America',
+			hasChildren: false,
+			parent: state.id
+		});
 	});
+
+	return createSyncStore({ data: topHeavyData }, Tree).getRootCollection();
 });

--- a/test/intern/core/_StoreMixin.js
+++ b/test/intern/core/_StoreMixin.js
@@ -355,20 +355,6 @@ define([
 					assert.strictEqual(cell.element.innerHTML, newValue, 'Displayed cell value should change');
 				});
 			});
-
-			test.test('widget destruction', function () {
-				var cell = grid.cell('2', 'col3');
-				var widget = cell.element.widget;
-				var wasDestroyed = false;
-
-				aspect.after(widget, 'destroy', function () {
-					wasDestroyed = true;
-				});
-
-				return grid.refreshCell(cell).then(function () {
-					assert.isTrue(wasDestroyed, 'Cell\'s editor widget should be destroyed when refreshCell runs');
-				});
-			});
 		});
 
 		test.suite('_StoreMixin#save', function () {

--- a/test/intern/mixins/Editor.js
+++ b/test/intern/mixins/Editor.js
@@ -601,5 +601,55 @@ define([
 				});
 			});
 		});
+
+		test.suite('Editor#refreshCell', function () {
+			test.beforeEach(function () {
+				grid = new EditorGrid({
+					columns: {
+						order: {
+							label: 'Order',
+							editor: 'text'
+						},
+						name: {
+							label: 'Name',
+							editor: TextBox
+						}
+					}
+				});
+
+				document.body.appendChild(grid.domNode);
+				grid.startup();
+				grid.renderArray(testOrderedData);
+			});
+
+			test.afterEach(function () {
+				if (grid) {
+					grid.destroy();
+					grid = null;
+				}
+			});
+
+			test.test('editor: HTML input', function () {
+				var cell = grid.cell('2', 'order');
+				var oldValue = cell.element.input.value;
+
+				cell.element.input.value = 'new value';
+
+				return grid.refreshCell(cell).then(function () {
+					assert.strictEqual(cell.element.input.value, oldValue, 'Displayed cell value should change');
+				})
+			});
+
+			test.test('editor: Dijit TextBox', function () {
+				var cell = grid.cell('2', 'name');
+				var oldValue = cell.element.widget.get('value');
+
+				cell.element.widget.set('value', 'new value');
+
+				return grid.refreshCell(cell).then(function () {
+					assert.strictEqual(cell.element.widget.get('value'), oldValue, 'Displayed cell value should change');
+				})
+			});
+		});
 	});
 });

--- a/test/intern/mixins/Selector.js
+++ b/test/intern/mixins/Selector.js
@@ -92,5 +92,17 @@ define([
 				}
 			}
 		});
+
+		test.test('Selector#refreshCell should have no effect', function () {
+			var cell = grid.cell(0, 'select');
+			var editorNode = cell.element.input;
+			var newValue = !editorNode.checked;
+
+			editorNode.checked = newValue;
+
+			return grid.refreshCell(cell).then(function () {
+				assert.strictEqual(cell.element.input.checked, newValue, 'Selector value should not change');
+			});
+		});
 	});
 });

--- a/test/intern/mixins/Tree-indent.js
+++ b/test/intern/mixins/Tree-indent.js
@@ -74,6 +74,16 @@ define([
 
 			test.test('level 1', level1Test);
 			test.test('level 2', level2Test);
+
+			test.test('refreshCell', function () {
+				return grid.expand('AF').then(function () {
+					return grid.expand('EG');
+				}).then(function () {
+					var cell = grid.cell('Cairo', '0');
+
+					return grid.refreshCell(cell).then(level2Test);
+				});
+			});
 		});
 
 		test.suite('OnDemandGrid + tree + compound columns + column sets', function () {


### PR DESCRIPTION
* `Editor#refreshCell`: does not re-render cell; just re-sets editor value from data
* `Selector#refreshCell`: does nothing
* `Tree#refreshCell`: preserves indentation level
* Add unit tests for these changes
* `test/data/testTopHeavyHierarchicalStore.js`: fix data format