### PR TITLE
Prevent default and programatically scroll for end/home keys

### DIFF
--- a/Keyboard.js
+++ b/Keyboard.js
@@ -514,6 +514,7 @@ define([
 		//		Handles requests to scroll to the beginning or end of the grid.
 
 		// Assume scrolling to top unless event is specifically for End key
+		event.preventDefault();
 		var cellNavigation = this.cellNavigation,
 			contentNode = this.contentNode,
 			contentPos = scrollToTop ? 0 : contentNode.scrollHeight,
@@ -523,7 +524,9 @@ define([
 			endTarget = hasPreload ? endChild[(scrollToTop ? 'next' : 'previous') + 'Sibling'] : endChild,
 			endPos = endTarget.offsetTop + (scrollToTop ? 0 : endTarget.offsetHeight),
 			handle;
-
+		this.scrollTo({
+			y: scrollPos
+		});
 		if (hasPreload) {
 			// Find the nearest dgrid-row to the relevant end of the grid
 			while (endTarget && endTarget.className.indexOf('dgrid-row') < 0) {

--- a/test/data/testPerformanceStore.js
+++ b/test/data/testPerformanceStore.js
@@ -1,6 +1,7 @@
 define([ './createSyncStore' ], function (createSyncStore) {
 	var perfData = [], today = new Date().getTime();
-	for (var i = 0; i < 20000; i++) {
+	// With the size of these rows, 14500 rows butts right up against the magical IE height limit.
+	for (var i = 0; i < 14500; i++) {
 		perfData.push({
 			id: i,
 			integer: Math.floor(Math.random() * 100),

--- a/test/intern/core/stores.js
+++ b/test/intern/core/stores.js
@@ -77,7 +77,7 @@ define([
 		testPerformanceStore.putSync(testPerformanceStore.getSync(0));
 		assert.strictEqual(numInserts, 0,
 			'Item from unrendered range should not be added to grid when updated');
-		testPerformanceStore.putSync(testPerformanceStore.getSync(visibleId || 19999));
+		testPerformanceStore.putSync(testPerformanceStore.getSync(visibleId || 14499));
 		assert.strictEqual(numInserts, 1,
 			'Item from rendered range should be re-added to grid when updated');
 	}

--- a/test/intern/functional/Keyboard.html
+++ b/test/intern/functional/Keyboard.html
@@ -13,6 +13,7 @@
 		<div id="list-ondemand"></div>
 		<div id="grid-ondemand"></div>
 		<div id="rowGrid-ondemand"></div>
+		<div id="grid-large-data-set"></div>
 		<script src="../../../../dojo/dojo.js"></script>
 		<script>
 			var grid, list, rowGrid, ready;
@@ -26,8 +27,9 @@
 				'dojo/on',
 				'dojo/query',
 				'dgrid/test/data/createSyncStore',
-				'dgrid/test/data/genericData'
-			], function(OnDemandList, List, OnDemandGrid, Grid, Keyboard, declare, on, query, createSyncStore, genericData){
+				'dgrid/test/data/genericData',
+				'dgrid/test/data/testPerformanceStore'
+			], function(OnDemandList, List, OnDemandGrid, Grid, Keyboard, declare, on, query, createSyncStore, genericData, largeDataSetStore){
 				var columns = {
 						col1: 'Column 1',
 						col2: 'Column 2',
@@ -74,6 +76,21 @@
 					columns: columns,
 					cellNavigation: false
 				}, 'rowGrid-ondemand');
+				largeDataSetGrid = new KeyboardOnDemandGrid({
+					collection: largeDataSetStore,
+					columns: {
+						col1: { label: 'Column 0', field: 'id', width: '10%' },
+						col2: { label: 'Column 1', field: 'integer', width: '10%' },
+						col3: { label: 'Column 2', field: 'floatNum', width: '10%' },
+						col4: { label: 'Column 3', field: 'date', width: '10%' },
+						col5: { label: 'Column 4', field: 'date2', width: '10%' },
+						col6: { label: 'Column 5', field: 'text', width: '10%' },
+						col7: { label: 'Column 6', field: 'bool', width: '10%' },
+						col8: { label: 'Column 7', field: 'bool2', width: '10%' },
+						col9: { label: 'Column 8', field: 'price', width: '10%' },
+						col10: { label: 'Column 9', field: 'today', width: '10%' }
+					}
+				}, 'grid-large-data-set');
 				ready = true;
 			});
 		</script>

--- a/test/intern/functional/Keyboard.js
+++ b/test/intern/functional/Keyboard.js
@@ -61,7 +61,7 @@ define([
 		};
 	}
 
-	function testHomeEndKeys(gridId, cellNavigation) {
+	function testHomeEndKeys(gridId, cellNavigation, rowCount) {
 		var rootQuery = '#' + gridId + ' #' + gridId + '-row-';
 		return function () {
 			return this.remote
@@ -70,8 +70,7 @@ define([
 					.type([keys.END])
 					.end()
 				.setFindTimeout(1000)
-				// Note that this assumes the list is always 100 items, 0-99
-				.findByCssSelector('#' + gridId + '-row-99' + (cellNavigation ? ' .dgrid-column-col1' : ''))
+				.findByCssSelector('#' + gridId + '-row-' + (rowCount ? rowCount : 99) + (cellNavigation ? ' .dgrid-column-col1' : ''))
 					.getAttribute('class')
 					.then(function (classNames) {
 						var arr = classNames.split(' '),
@@ -129,12 +128,15 @@ define([
 			testHomeEndKeys('list'));
 
 		test.test('on-demand grid (cellNavigation: true) -> home + end keys',
-			testHomeEndKeys('grid-ondemand', true, true));
+			testHomeEndKeys('grid-ondemand', true));
 
 		test.test('on-demand simple grid (cellNavigation: false) -> home + end keys',
-			testHomeEndKeys('rowGrid-ondemand', false, true));
+			testHomeEndKeys('rowGrid-ondemand', false));
 
 		test.test('on-demand simple list -> home + end keys',
-			testHomeEndKeys('list-ondemand', false, true));
+			testHomeEndKeys('list-ondemand', false));
+
+		test.test('on-demand grid with large data set -> home + end keys',
+			testHomeEndKeys('grid-large-data-set', true, 14499));
 	});
 });


### PR DESCRIPTION
Fixes #1278
Smooth scrolling by the browser causes renderArray to be
called multiple times, unnecessarily, when the end or home
key is pressed. This also causes the grid to display the
wrong data because an aspect on renderArray fires for the
first set of rows when it is expecting to only fire once.

Preventing the default behavior and progrmmatically
scrolling instead resolves this issue.

This fix also reduces the number of rows in the performance
test from 20000 to 14500. This reduced number creates a
grid that is slightly under the maximum height limit in
IE, so that home/end functionality can be tested in a
functional test in all browsers.