### PR TITLE
fix: remove ambiguous "this" in favor of passed event and currentTarget

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -204,9 +204,9 @@ define([
 				// which we already advocate in docs for optimal use)
 
 				if (!options || !options.alreadyHooked) {
-					var listener = on(cell, editOn, function () {
+					var listener = on(cell, editOn, function (event) {
 						self._activeOptions = options;
-						self.edit(this);
+						self.edit(event.currentTarget);
 					});
 					if (self._editorRowListeners) {
 						self._editorRowListeners[column.id] = listener;


### PR DESCRIPTION
"this" can be ambiguous in JS. So let's use the event that's already passed to the function.