### PR TITLE
OnDemandList: remove obsolete 'preserveMomentum' option

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -750,12 +750,8 @@ define([
 									// if the preload area above the nodes is approximated based on average
 									// row height, we may need to adjust the scroll once they are filled in
 									// so we don't "jump" in the scrolling position
-									var pos = grid.getScrollPosition();
 									grid.scrollTo({
-										// Since we already had to query the scroll position,
-										// include x to avoid TouchScroll querying it again on its end.
-										x: pos.x,
-										y: pos.y + beforeNode.offsetTop - keepScrollTo
+										y: grid.bodyNode.scrollTop + beforeNode.offsetTop - keepScrollTo
 									});
 								}
 


### PR DESCRIPTION
The `TouchScroll` module was removed in the 1.x branch.
This option no longer serves any purpose.
