### PR TITLE
Propagate resolved value of 'renderQuery' promise through 'refresh'

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -301,8 +301,9 @@ define([
 						start: queryOptions.start,
 						end: queryOptions.start + queryOptions.count
 					});
-				}).then(function () {
+				}).then(function (rows) {
 					self._emitRefreshComplete();
+					return rows;
 				});
 			}
 		},

--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -279,7 +279,8 @@ define([
 			//			property's value for this specific refresh call only.
 
 			var self = this,
-				keep = (options && options.keepScrollPosition);
+				keep = (options && options.keepScrollPosition),
+				fetchResults;
 
 			// Fall back to instance property if option is not defined
 			if (typeof keep === 'undefined') {
@@ -294,16 +295,25 @@ define([
 			this.inherited(arguments);
 			if (this._renderedCollection) {
 				// render the query
-
 				// renderQuery calls _trackError internally
 				return this.renderQuery(function (queryOptions) {
-					return self._renderedCollection.fetchRange({
+					var queryResults = self._renderedCollection.fetchRange({
 						start: queryOptions.start,
 						end: queryOptions.start + queryOptions.count
 					});
-				}).then(function (rows) {
+
+					queryResults.then(function (results) {
+						fetchResults = results;
+					});
+
+					// It is important to return the original QueryResults object, which is a special promise
+					// with 'totalLength' and 'forEach' properties on it. Returning a chained promise would
+					// lose these properties.
+					return queryResults;
+				}).then(function () {
 					self._emitRefreshComplete();
-					return rows;
+
+					return fetchResults;
 				});
 			}
 		},

--- a/test/intern/core/OnDemandList.js
+++ b/test/intern/core/OnDemandList.js
@@ -44,5 +44,14 @@ define([
 			// This tests GitHub issue #965.
 			assert.strictEqual(query('.dgrid-row', list.contentNode).length, list.minRowsPerPage);
 		});
+
+		test.test('refresh should return a QueryResults object', function () {
+			var dfd = this.async();
+
+			list.refresh().then(dfd.callback(function (results) {
+				assert.property(results, 'forEach');
+				assert.property(results, 'totalLength');
+			}));
+		});
 	});
 });

--- a/test/intern/extensions/Pagination.js
+++ b/test/intern/extensions/Pagination.js
@@ -109,6 +109,15 @@ define([
 			store.putSync({ id: 2 });
 			assert.strictEqual(pageNumber, 1, 'Should have refreshed page 1 after adding the first item');
 		});
+
+		test.test('refresh should return a QueryResults object', function () {
+			var dfd = this.async();
+
+			grid.refresh().then(dfd.callback(function (results) {
+				assert.property(results, 'forEach');
+				assert.property(results, 'totalLength');
+			}));
+		});
 	});
 
 	test.suite('Pagination size selector initialization tests', function () {


### PR DESCRIPTION
The `renderQuery` method returns a promise that resolves to an array of the rendered row elements. It appears to be an oversight that this value is discarded by the `refresh` method.
