### PR TITLE
use relative require path

### DIFF
--- a/extensions/SingleQuery.js
+++ b/extensions/SingleQuery.js
@@ -1,7 +1,7 @@
 define([
 	'dojo/_base/declare',
 	'dojo/dom-construct',
-	'dgrid/_StoreMixin'
+	'../_StoreMixin'
 ], function (declare, domConstruct, _StoreMixin) {
 	return declare(_StoreMixin, {
 		// summary:


### PR DESCRIPTION
if you have for some crazy reason two versions of dgrid, without a map, this require can request the wrong `_StoreMixin`.