### PR TITLE
Fix drag avatar for recently changed item

### DIFF
--- a/extensions/DnD.js
+++ b/extensions/DnD.js
@@ -295,11 +295,25 @@ define([
 				data: object,
 				type: type instanceof Array ? type : [type]
 			});
+
+			if (this.selection) {
+				var objectId = this.collection.getIdentity(object);
+				if (objectId in this.selection) {
+					this.dndSource._selectedNodes[objectId] = row;
+				}
+			}
+
 			return row;
 		},
 
 		removeRow: function (rowElement) {
-			this.dndSource.delItem(this.row(rowElement));
+			var row = this.row(rowElement);
+
+			if (this.selection && (row.id in this.selection)) {
+				delete this.dndSource._selectedNodes[row.id];
+			}
+
+			this.dndSource.delItem(row.element.id);
 			this.inherited(arguments);
 		}
 	});


### PR DESCRIPTION
If a user drags a row that has just been edited, the drag avatar will be blank. The reason is that the `_selectedNodes` object is never updated after the grid removes and creates a new row for the `put` operation.