### PR TITLE
Pagination: add warning when mixed with OnDemandList

### DIFF
--- a/extensions/Pagination.js
+++ b/extensions/Pagination.js
@@ -101,6 +101,11 @@ define([
 				navigationNode,
 				node;
 
+			if (typeof this._processScroll === 'function') {
+				this.bodyNode.innerHTML = i18n.notCompatibleWithOnDemand;
+				console.warn(i18n.notCompatibleWithOnDemand);
+			}
+
 			statusNode.tabIndex = 0;
 
 			// Initialize UI based on pageSizeOptions and rowsPerPage

--- a/extensions/nls/pagination.js
+++ b/extensions/nls/pagination.js
@@ -7,7 +7,8 @@ define({
 		gotoLast: 'Go to last page',
 		gotoPage: 'Go to page',
 		jumpPage: 'Jump to page',
-		rowsPerPage: 'Number of rows per page'
+		rowsPerPage: 'Number of rows per page',
+		notCompatibleWithOnDemand: 'Pagination is not compatible with OnDemandList'
 	},
 	ar: true,
 	de: true,


### PR DESCRIPTION
Fixes #1367

I can't determine any simple way to disable one extension or the other if a conflict is detected. I think you would have to do a conflict check early in the lifecycle, set a flag, and then check that flag in every single method of the mixin. The solution in this PR is a very minimal change, and very clearly presents the message in the rendered grid.

There's no need to add a check in `OnDemandList` since if the two are mixed in then both will run, so doing a conflict check in both modules just duplicates logic.