### PR TITLE
Make column hider button appear when there are no scrollbars

### DIFF
--- a/css/dgrid.css
+++ b/css/dgrid.css
@@ -198,6 +198,7 @@ html.has-mozilla .dgrid-focus {
   position: absolute;
   right: 0;
   top: 0;
+  z-index: 99999;
 }
 .dgrid-rtl-swap .dgrid-hider-toggle {
   right: auto;

--- a/extensions/ColumnHider.js
+++ b/extensions/ColumnHider.js
@@ -147,7 +147,7 @@ define([
 				// First run
 				// Assume that if this plugin is used, then columns are hidable.
 				// Create the toggle node.
-				hiderToggleNode = this.hiderToggleNode = domConstruct.create('button', {
+				hiderToggleNode = this.hiderToggleNode = domConstruct.create('div', {
 					'aria-label': this.i18nColumnHider.popupTriggerLabel,
 					className: 'ui-icon dgrid-hider-toggle',
 					type: 'button'
@@ -157,7 +157,7 @@ define([
 				// browsers. Hopefully any browsers (or updates) introduced since then that reduce the scrollbar width
 				// also include support for scaling with CSS transforms.
 				scrollbarWidth = this.bodyNode.offsetWidth - this.bodyNode.clientWidth;
-				if (scrollbarWidth < 16) {
+				if (scrollbarWidth < 16 && scrollbarWidth > 0) {
 					hiderNodeScale = scrollbarWidth / 16;
 					hiderNodeTranslate = (16 - scrollbarWidth) / 2;
 					hiderToggleNode.style.transform = 'scale(' + (hiderNodeScale) + ') translate(' +


### PR DESCRIPTION
Fix bug causing the column hider button to not appear when no scrollbars are used.  

Fix #1371

Also fixes:
- Because <button> is used for the column hider button, an additional background image is bleeding into the button on iOS.  Change the implementation to use a <div> instead.
- When the column hider extension is used with the column resize extension, the column hider button cannot be clicked when there are no scrollbars.   Update the CSS to allow the column button to be clicked.