### PR TITLE
Fix for cases that cause the DnD module to incorrectly order rows.

### DIFF
--- a/extensions/DnD.js
+++ b/extensions/DnD.js
@@ -109,7 +109,10 @@ define([
 						// multiple, non-adjacent rows are being dragged.
 						var objectId = store.getIdentity(object);
 						var targetId = targetItem ? store.getIdentity(targetItem) : null;
-						var promise = objectId === targetId ? when(true) :
+						var promise = objectId === targetId ? targetSource._getNextItem(targetItem)
+							.then(function (nextItem) {
+								targetItem = nextItem;
+							}) :
 							store[copy && store.copy ? 'copy' : 'put'](object, {
 								beforeId: targetId
 							});
@@ -124,6 +127,21 @@ define([
 				});
 			});
 		},
+
+		_getNextItem: function (item) {
+			var grid = this.grid;
+			if (item) {
+				var row = grid.row(item);
+				if (row.element) {
+					row = grid.down(row);
+					if (row.element) {
+						return grid.collection.get(row.id);
+					}
+				}
+			}
+			return when(null);
+		},
+
 		onDropExternal: function (sourceSource, nodes, copy, targetItem) {
 			// Note: this default implementation expects that two grids do not
 			// share the same store.  There may be more ideal implementations in the

--- a/extensions/DnD.js
+++ b/extensions/DnD.js
@@ -135,7 +135,7 @@ define([
 				if (row.element) {
 					row = grid.down(row);
 					if (row.element) {
-						return grid.collection.get(row.id);
+						return when(row.data);
 					}
 				}
 			}


### PR DESCRIPTION
When rows are dropped, adjust the target row if the target row is among the rows being moved.

Fix #1377