### PR TITLE
Update ensure scroll to handle scrolling to a row properly

### DIFF
--- a/Keyboard.js
+++ b/Keyboard.js
@@ -330,16 +330,20 @@ define([
 			}
 		},
 
-		_ensureScroll: function (cell, isHeader) {
+		_ensureScroll: function (rowOrCell, isHeader) {
 			// summary:
 			//		Corrects scroll based on the position of the newly-focused row/cell
 			//		as necessary based on grid configuration and dimensions.
+			var isRow = !rowOrCell.column && !rowOrCell.row && rowOrCell.data && rowOrCell.element;
 
+			if(isRow) {
+				this._ensureRowScroll(rowOrCell.element);
+			}
 			if(this.cellNavigation && (this.columnSets || this.subRows.length > 1) && !isHeader){
-				this._ensureRowScroll(cell.row.element);
+				this._ensureRowScroll(rowOrCell.row.element);
 			}
 			if(this.bodyNode.clientWidth < this.contentNode.offsetWidth){
-				this._ensureColumnScroll(cell.element);
+				this._ensureColumnScroll(rowOrCell.element);
 			}
 		},
 

--- a/Keyboard.js
+++ b/Keyboard.js
@@ -339,11 +339,13 @@ define([
 			if(isRow) {
 				this._ensureRowScroll(rowOrCell.element);
 			}
-			if(this.cellNavigation && (this.columnSets || this.subRows.length > 1) && !isHeader){
-				this._ensureRowScroll(rowOrCell.row.element);
-			}
-			if(this.bodyNode.clientWidth < this.contentNode.offsetWidth){
-				this._ensureColumnScroll(rowOrCell.element);
+			else {
+				if(this.cellNavigation && (this.columnSets || this.subRows.length > 1) && !isHeader){
+					this._ensureRowScroll(rowOrCell.row.element);
+				}
+				if(this.bodyNode.clientWidth < this.contentNode.offsetWidth){
+					this._ensureColumnScroll(rowOrCell.element);
+				}
 			}
 		},
 


### PR DESCRIPTION
[`_focusOnNode`](https://github.com/SitePen/dgrid/blob/master/Keyboard.js#L356) handles both rows and cells, and in either case passes the object to [`_ensureScroll`](https://github.com/SitePen/dgrid/blob/master/Keyboard.js#L429), but [`_ensureScroll`](https://github.com/SitePen/dgrid/blob/master/Keyboard.js#L340) just assumes that it will be dealing with a cell.

This would just update `_ensureScroll` to handle rows as well.