### PR TITLE
Fix use of querySelectorAll.

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -393,7 +393,7 @@ define([
 			while (preload) {
 				if (!preload.rowHeight) {
 					preload.rowHeight = this.rowHeight ||
-						this._calcAverageRowHeight(preload.node.parentNode.querySelectorAll('dgrid-row'));
+						this._calcAverageRowHeight(preload.node.parentNode.querySelectorAll('.dgrid-row'));
 					this._adjustPreloadHeight(preload);
 				}
 				preload = preload.next;

--- a/test/intern/core/OnDemandList.js
+++ b/test/intern/core/OnDemandList.js
@@ -45,4 +45,31 @@ define([
 			assert.strictEqual(query('.dgrid-row', list.contentNode).length, list.minRowsPerPage);
 		});
 	});
+
+	test.suite('OnDemandList', function () {
+		var list;
+		var store = createSyncStore({ data: genericData });
+
+		test.beforeEach(function () {
+			list = new OnDemandList({
+				collection: store,
+				renderRow: function () {
+					var node = document.createElement('div');
+					node.innerHTML = 'Test';
+					node.style.height = '16px';
+					return node;
+				}
+			});
+			document.body.appendChild(list.domNode);
+			list.startup();
+		});
+
+		test.afterEach(function () {
+			list.destroy();
+		});
+
+		test.test('calculated row height', function () {
+			assert.strictEqual(16, list.preload.rowHeight);
+		});
+	});
 });

--- a/test/intern/mixins/Editor.js
+++ b/test/intern/mixins/Editor.js
@@ -497,7 +497,8 @@ define([
 			var cellContent;
 			return addDelay(grid.edit(cell)).then(function () {
 				cellContent = cell.element.innerHTML;
-				grid.refresh();
+				return addDelay(grid.refresh());
+			}).then(function () {
 				cell = grid.cell(1, 'name');
 				return addDelay(grid.edit(cell));
 			}).then(function () {


### PR DESCRIPTION
A period was missing from the CSS selector in OnDemandList's use of querySelectorAll.  This caused the average row height to always be zero.  

I added a test to verify the calculation of the average row height.