### PR TITLE
fix rowHeight value to reflect average row height

### DIFF
--- a/OnDemandList.js
+++ b/OnDemandList.js
@@ -384,6 +384,7 @@ define([
 
 		_updatePreloadRowHeights: function () {
 			var preload = this.preload;
+			var rowHeight = 0;
 			if (!preload) {
 				return;
 			}
@@ -392,12 +393,14 @@ define([
 			}
 			while (preload) {
 				if (!preload.rowHeight) {
-					preload.rowHeight = this.rowHeight ||
+					preload.rowHeight = 
 						this._calcAverageRowHeight(preload.node.parentNode.querySelectorAll('.dgrid-row'));
 					this._adjustPreloadHeight(preload);
 				}
+				rowHeight = preload ? preload.rowHeight : rowHeight;
 				preload = preload.next;
 			}
+			this.rowHeight = rowHeight;
 		},
 
 		lastScrollTop: 0,

--- a/test/intern/core/OnDemandList.js
+++ b/test/intern/core/OnDemandList.js
@@ -70,6 +70,7 @@ define([
 
 		test.test('calculated row height', function () {
 			assert.strictEqual(16, list.preload.rowHeight);
+			assert.strictEqual(16, list.rowHeight);
 		});
 	});
 });


### PR DESCRIPTION
The `rowHeight` property in OnDemandList is currently not getting set to a value but it used to influence the average row height calculations. This change updates the `rowHeight` property to be the value latest preload `rowHeight`.