### PR TITLE
Fix a bug with keyboard navigation when there is no data

### DIFF
--- a/Keyboard.js
+++ b/Keyboard.js
@@ -460,6 +460,9 @@ define([
 	// Common functions used in default keyMap (called in instance context)
 
 	var moveFocusVertical = Keyboard.moveFocusVertical = function (event, steps) {
+		// if there is no _focusNode (for example, when the grid doesn't have data) don't try to find the next focus row/cell
+		if (!this._focusedNode) { return; }
+
 		var cellNavigation = this.cellNavigation,
 			target = this[cellNavigation ? 'cell' : 'row'](event),
 			columnId = cellNavigation && target.column.id,


### PR DESCRIPTION
When Keyboard.js is mixed into a grid and the grid does not have any data, when the grid gets focus, using the up or down arrow keys, or the Page Up or Page Down buttons will cause an error and log it in the console window. I've created an example of this here: http://plnkr.co/edit/iI2TuSy5HnrhSmEqulED (open the F12 console to see the errors). 

This should fix the issue by not trying to navigate if no node is focused.