### PR TITLE
Don't mark the selector element as disabled

### DIFF
--- a/Selector.js
+++ b/Selector.js
@@ -40,7 +40,7 @@ define([
 			return (cell.input = domConstruct.create('input', {
 				'aria-checked': selected,
 				checked: selected,
-				disabled: !grid.allowSelect(grid.row(object)),
+				readonly: !grid.allowSelect(grid.row(object)),
 				tabIndex: isNaN(column.tabIndex) ? -1 : column.tabIndex,
 				type: column.selector
 			}, cell));
@@ -155,8 +155,8 @@ define([
 						continue;
 					}
 					element = (element.contents || element).input;
-					if (element && !element.disabled) {
-						// Only change the value if it is not disabled
+					if (element && !element.readonly) {
+						// Only change the value if it is not read-only
 						element.checked = value;
 						element.setAttribute('aria-checked', value);
 					}


### PR DESCRIPTION
Disabled elements eat click events at least in Firefox. A read-only element serves the original purpose and allows clicking on the element itself.