### PR TITLE
Addrowdelrow

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,7 @@ available to further expand dgrid's functionality.
     * [SingleQuery](components/extensions/SingleQuery.md)
     * [DijitRegistry](components/extensions/DijitRegistry.md)
     * [DnD](components/extensions/DnD.md)
+    * [AddRowDelRow](components/extensions/AddRowDelRow.md)
 * Utilities
     * [touch](components/utilities/touch.md)
     * [misc](components/utilities/misc.md)

--- a/doc/components/extensions/AddRowDelRow.md
+++ b/doc/components/extensions/AddRowDelRow.md
@@ -24,17 +24,25 @@ require([
   var store = new Memory();
   var grid = new (declare([OnDemandGrid, Selection, Editor, AddRowDelRow]))({
       collection: store,
-      columns: {
-          name: {
-              editor: 'text'
-          },
-          bool: {
-              editor: 'checkbox'
-          }
-      }
+        columns: {
+            col1: {
+                editor: 'text'
+            },
+            col2: {
+                editor: 'checkbox'
+            }
+        }
   }, 'grid');
 
   grid.startup();
-  grid.addRow({name: "name1"});
-  grid.addRow({name: "name2"});
+  grid.addRow({col1: "value1a", col2: false});
+  grid.addRow({col1: "value1b", col2: true});
+  grid.addRow({col1: "value1c", col2: false});
 ```
+## Result
+
+| col1 | col2 | ➕ |  
+| --- | --- | --- |  
+| value1a | ☐ | ❌ |  
+| value1b | ☑ | ❌ |  
+| value1c | ☐ | ❌ |  

--- a/doc/components/extensions/AddRowDelRow.md
+++ b/doc/components/extensions/AddRowDelRow.md
@@ -1,7 +1,7 @@
 # AddRowDelRow
-The AddRowDelRow component adds two new related funcionalities:
-A ➕ button on the header to create a new, empty row at the end of the table.
-A ❌ button on each body row to remove that row.
+The AddRowDelRow component adds two new related funcionalities:  
+ - A ➕ button on the header to create a new, empty row at the end of the table.
+ - A ❌ button on each body row to remove that row.
 
 ## How to use
 This is a simple mixin with no required setup or dependencies.

--- a/doc/components/extensions/AddRowDelRow.md
+++ b/doc/components/extensions/AddRowDelRow.md
@@ -1,0 +1,40 @@
+# AddRowDelRow
+The AddRowDelRow component adds two new related funcionalities:
+A ➕ button on the header to create a new, empty row at the end of the table.
+A ❌ button on each body row to remove that row.
+
+## How to use
+This is a simple mixin with no required setup or dependencies.
+The only attention point is that the remove row violates the packaging and calls the `remove()` method directly on the store.  
+So in the rare case the `grid.collection` is a not a `dstore` object this may be a issue which must be handled.
+
+## Example
+```js
+require([
+    'dojo/_base/declare',
+    'dojo/dom',
+    'dojo/on', 
+    'dstore/Memory',
+    'dgrid/OnDemandGrid',
+    'dgrid/Selection',
+    'dgrid/Editor',
+    'dgrid/extensions/AddRowDelRow',
+    'dojo/domReady!'
+], function(declare, dom, on, Memory, OnDemandGrid, Selection, Editor, AddRowDelRow) {
+  var store = new Memory();
+  var grid = new (declare([OnDemandGrid, Selection, Editor, AddRowDelRow]))({
+      collection: store,
+      columns: {
+          name: {
+              editor: 'text'
+          },
+          bool: {
+              editor: 'checkbox'
+          }
+      }
+  }, 'grid');
+
+  grid.startup();
+  grid.addRow({name: "name1"});
+  grid.addRow({name: "name2"});
+```

--- a/extensions/AddRowDelRow.js
+++ b/extensions/AddRowDelRow.js
@@ -1,0 +1,43 @@
+define([
+	'dojo/_base/declare',
+	'dojo/_base/lang',
+	'dojo/dom-construct',
+	'dojo/on',
+], function (declare, lang, domConstruct, on) {
+	return declare(null, {
+		renderHeader: function () {
+			var grid = this;
+
+			this.inherited(arguments);
+
+			// create a additional column with the + icon to add a new row
+			var cell = domConstruct.create('th', {className: "dgrid-cell dgrid-sortable dgrid-page-input", innerHTML: '➕'}, this.headerNode.firstChild.firstChild);
+			on(cell, "click", function (e) {
+				grid.addRow();
+			});
+
+		},
+		renderRow: function (item, options) {
+			var grid = this;
+			var row = this.createRowCells('td', lang.hitch(this, '_createBodyRowCell'), options && options.subRows, item, options);
+			var cell = domConstruct.create('td', {className: "dgrid-cell dgrid-sortable dgrid-page-input", innerHTML: '❌'}, row.firstChild);
+			on(cell, "click", function (e) {
+				grid.delRow(grid.row(e.target))
+			});
+			var div = domConstruct.create('div', { role: 'row' });
+			div.appendChild(row);
+			return div;
+		},
+		delRow: function(row) {
+			this.collection.remove(row.data.id);
+			this.removeRow(row);
+		},
+		addRow: function(data) {
+			if (data === undefined) {
+				data = {};
+			}
+			this.collection.add(data);
+			this.refresh();
+		}
+	});
+});

--- a/test/extensions/addRowDelRow_dstore.html
+++ b/test/extensions/addRowDelRow_dstore.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Test Add Row Del Row</title>
+    <meta name="viewport" content="width=570">
+    <style>
+      /*
+      @import "/siteassets/dojo/resources/dojo.css";
+      @import "/siteassets/dgrid/css/dgrid.css";
+      @import "/siteassets/dgrid/css/skins/claro.css";
+      */
+      @import "../../dojo/resources/dojo.css";
+      @import "../css/dgrid.css";
+      @import "../css/skins/claro.css";
+
+      .heading {
+        font-weight: bold;
+        padding-bottom: 0.25em;
+      }
+      .dgrid {
+        margin: 10px;
+      }
+      /* add styles to size this grid appropriately */
+      #grid {
+        height: 20em;
+      }
+      #grid .field-order {
+        width: 7%;
+      }
+      #grid .field-name {
+        width: 18%;
+      }
+    </style>
+    <!--
+    <script src="/siteassets/init.js" data-dojo-config="async: true"></script>
+    -->
+    <script src="../../dojo/dojo.js" data-dojo-config="async: true"></script>
+    <script>
+      var columns = {
+        order: "step", // give column a custom name
+        name: {},
+        description: {label: "what to do", sortable: false}
+      };
+      var columns2 = {
+        name: {},
+        description: {label: "what to do", sortable: false}
+      };
+      //require(['dojo/_base/declare',"dgrid/Grid", 'dgrid/OnDemandList', 'dstore/Memory', '../siteassets/AddRowDelRow.js', "dojo/domReady!"], function(declare, Grid, OnDemandList, dstoreMemory, AddRowDelRow){
+      require(['dojo/_base/declare',"dgrid/Grid", 'dgrid/OnDemandList', 'dstore/Memory', 'dstore/extensions/AddRowDelRow', "dojo/domReady!"], function(declare, Grid, OnDemandList, dstoreMemory, AddRowDelRow){
+        var data = [
+          {id: 1, order: 1, name:"preheat", description:"Preheat your oven to 350F"},
+          {id: 2, order: 2, name:"mix dry", description:"In a medium bowl, combine flour, salt, and baking soda"},
+          {id: 3, order: 3, name:"mix butter", description:"In a large bowl, beat butter, then add the brown sugar and white sugar then mix"},
+          {id: 4, order: 4, name:"mix together", description:"Slowly add the dry ingredients from the medium bowl to the wet ingredients in the large bowl, mixing until the dry ingredients are totally combined"},
+          {id: 5, order: 5, name:"chocolate chips", description:"Add chocolate chips"},
+          {id: 6, order: 6, name:"make balls", description:"Scoop up a golf ball size amount of dough with a spoon and drop in onto a cookie sheet"},
+          {id: 7, order: 7, name:"bake", description:"Put the cookies in the oven and bake for about 10-14 minutes"},
+          {id: 8, order: 8, name:"remove", description:"Using a spatula, lift cookies off onto wax paper or a cooling rack"},
+          {id: 9, order: 9, name:"eat", description:"Eat and enjoy!"}
+        ];
+        var grid = new declare([Grid, OnDemandList, AddRowDelRow])({
+          collection: new dstoreMemory({data: data}),
+          columns: columns
+        }, "grid");
+        // grid.renderArray(data);
+        grid.startup();
+      });
+    </script>
+  </head>
+  <body class="claro">
+    <h2>A basic grid rendered from an array</h2>
+    <div id="grid"></div>
+    <div>Buttons to test resetting columns:
+      <button onclick="grid.set('columns', columns);">order, name, description</button>
+      <button onclick="grid.set('columns', columns2);">name, description</button>
+    </div>
+    <div>Buttons to test programmatic sort (on order field):
+      <button onclick="grid.set('sort', 'order');">Sort Asc</button>
+      <button onclick="grid.set('sort', 'order', true);">Sort Desc</button>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Adds a new simple mixin component with two related funcionalities:
A ➕ button on the header, on a "virtual" column to create a new, empty, row at the end of the table.
A ❌ button on each body row, on the same "virtual" column, to remove that row.
Mockup example of the result:  

| col1 | col2 | ➕ |  
| --- | --- | --- |  
| value1a | value2a | ❌ |  
| value1b | value2b | ❌ |  
| value1c | value2c | ❌ |  

I could not find any existing component that provides this kind of very useful funcionality so it may be a nice new addition to master.  
My approach to the `renderRow` override may be a bit hacky, but if nothing else its a good proof of concept to be reimplemented by someone with better undertanding of the dgrid practices.