### PR TITLE
Fix column hider not visible: set z-index of column hider

### DIFF
--- a/css/extensions/ColumnHider.styl
+++ b/css/extensions/ColumnHider.styl
@@ -6,6 +6,7 @@
 	position: absolute;
 	right: 0;
 	top: 0;
+	z-index: 99999;
 }
 
 .dgrid-rtl-swap .dgrid-hider-toggle {


### PR DESCRIPTION
PR #1372 updated `dgrid.css` but missed updating the Stylus source, this change
updates `ColumnHider.styl` as well