### PR TITLE
Prevent unnecessary deselect/select when an already selected item is selected

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -285,6 +285,12 @@ define([
 			//		except that clicks/keystrokes without modifier keys will clear
 			//		the previous selection.
 
+			// If the target is already selected, and is the sole selection, ignore a user action
+			// that would simply select the target (causing unnecessary deselect/select).
+			if (!event[ctrlEquiv] && this.isSelected(target) && this.getSelectedCount() === 1) {
+				return;
+			}
+
 			// Clear selection first for right-clicks outside selection and non-ctrl-clicks;
 			// otherwise, extended mode logic is identical to multiple mode
 			if (event.button === 2 ? !this.isSelected(target) :
@@ -641,6 +647,18 @@ define([
 				this._select(row.id, null, true);
 			}
 			this._fireSelectionEvents();
+		},
+
+		getSelectedCount: function () {
+			var count = 0;
+
+			for (var id in this.selection) {
+				if (id) {
+					count += 1;
+				}
+			}
+
+			return count;
 		},
 
 		isSelected: function (object) {

--- a/doc/components/mixins/Selection.md
+++ b/doc/components/mixins/Selection.md
@@ -65,6 +65,7 @@ Method | Description
 `selectAll()`| Programmatically selects all rows in the component. Note that only rows that have actually been loaded will be represented in the `selection` object.
 `clearSelection()`| Programmatically deselects all rows in the component.
 `isSelected(row)`| Returns `true` if the given row is selected.
+`getSelectedCount()` | Returns the number of selected rows/cells.
 
 **Note:** The `select`, `deselect`, and `isSelected` methods can be passed any
 type of argument acceptable to List's `row` method; see the [List](../core-components/List.md) APIs for


### PR DESCRIPTION
Fixes #1011

When a selected row or cell is clicked on (or focused and spacebar pressed) dgrid will deselect it (and fire a deselect event) and re-select it (and fire a select event). This PR prevents the unnecessary deselect/select process.