### PR TITLE
Fix error in pure AMD definition function

### DIFF
--- a/package.js
+++ b/package.js
@@ -28,7 +28,7 @@ var profile = {
 		},
 
 		amd: function (filename) {
-			return (/\.js$/).test(filename);
+			return (/\.js$/).test(filename) && !(/(html-report|nodes)\//).test(filename);
 		}
 	}
 };


### PR DESCRIPTION
The `profile.resourceTags.amd` function of the package.js file was set to discard the dgrid/css/nodes, dgrid/html-report directories as pure AMD. In this way, the dojo/util build process will not throw errors.

Without this, the build process throw this errors:
```
error(307) Failed to evaluate module tagged as pure AMD (fell back to processing with regular expressions). module: dgrid/css/nodes/color-image; error: TypeError: Cannot read property 'nodes' of undefined

error(307) Failed to evaluate module tagged as pure AMD (fell back to processing with regular expressions). module: dgrid/css/nodes/gradient; error: TypeError: Cannot read property 'nodes' of undefined

error(307) Failed to evaluate module tagged as pure AMD (fell back to processing with regular expressions). module: dgrid/css/nodes/vendor-helpers; error: ReferenceError: module is not defined

error(307) Failed to evaluate module tagged as pure AMD (fell back to processing with regular expressions). module: dgrid/html-report/prettify; error: ReferenceError: window is not defined

error(307) Failed to evaluate module tagged as pure AMD (fell back to processing with regular expressions). module: dgrid/html-report/sorter; error: ReferenceError: window is not defined
```