### PR TITLE
Keep track of focused editor cell so it persists after autosave

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -53,6 +53,7 @@ define([
 
 			if (previouslyFocusedCell && previouslyFocusedCell.row.id === row.id) {
 				this.edit(this.cell(row, previouslyFocusedCell.column.id));
+				this._previouslyFocusedEditorCell = null;
 			}
 			return rowElement;
 		},
@@ -283,6 +284,7 @@ define([
 				return null;
 			}
 
+			this._previouslyFocusedEditorCell = cell;
 			column = cell.column;
 			field = column.field;
 			cellElement = cell.element.contents || cell.element;


### PR DESCRIPTION
Editor cells using 'dgrid-cellfocusin' trigger an edit of the newly focused
cell followed by a row save (if autosave is true). The save process destroys
the row, updates the data, and re-renders the row. The result is that the
newly rendered row is no longer focused. This PR keeps track of the focused
editor cell during the edit process so that when the save triggers a re-render
the editor is correctly re-activated and focused.

Fixes #1298