### PR TITLE
Update build config

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,34 +1,45 @@
-var copyOnlyMids = {
-	'dgrid/Gruntfile': 1,
-	'dgrid/package': 1
-};
-var miniExcludeMids = {
-	'dgrid/CHANGES.md': 1,
-	'dgrid/LICENSE': 1,
-	'dgrid/README.md': 1,
-	'dgrid/Gruntfile': 1,
-	'dgrid/package': 1
-};
-
 // jshint unused: false
-var profile = {
-	resourceTags: {
-		copyOnly: function (filename, mid) {
-			return mid in copyOnlyMids;
+var profile = (function () {
+	var copyOnlyMids = {
+		'dgrid/Gruntfile': 1,
+		'dgrid/package': 1
+	};
+	var miniExcludeMids = {
+		'dgrid/CHANGES.md': 1,
+		'dgrid/LICENSE': 1,
+		'dgrid/README.md': 1,
+		'dgrid/Gruntfile': 1,
+		'dgrid/package': 1
+	};
+	var amdRegex = /\.js$/;
+	var isDemoRegex = /\/demos\//;
+	var isStylusRegex = /\.styl$/;
+	var isTestRegex = /\/test\//;
+
+	return {
+		resourceTags: {
+			copyOnly: function (filename, mid) {
+				return (mid in copyOnlyMids) || isDemoRegex.test(filename) || isTestRegex.test(filename);
+			},
+
+			test: function (filename) {
+				return isTestRegex.test(filename);
+			},
+
+			miniExclude: function (filename, mid) {
+				return isDemoRegex.test(filename) ||
+					isStylusRegex.test(filename) ||
+					isTestRegex.test(filename) ||
+					mid in miniExcludeMids;
+			},
+
+			amd: function (filename) {
+				return amdRegex.test(filename);
+			}
 		},
 
-		test: function (filename) {
-			return /\/test\//.test(filename);
-		},
-
-		miniExclude: function (filename, mid) {
-			return (/\/(?:test|demos)\//).test(filename) ||
-				(/\.styl$/).test(filename) ||
-			 	mid in miniExcludeMids;
-		},
-
-		amd: function (filename) {
-			return (/\.js$/).test(filename);
-		}
-	}
-};
+		trees: [
+			[ '.', '.', /(?:\/\.)|(?:~$)|(?:(?:html-report|node_modules|nib|nodes)\/)/ ]
+		]
+	};
+})();


### PR DESCRIPTION
* declare and re-use RegExp instances
* add `/demos` and `/test` to `copyOnly`
* trees: configure ignore option for
  * hidden files (.*)
  * backup files (*~)
  * `html-report` (Intern reporting info)
  * `node_modules`
  * `nib/nodes` (folders created by npm when Stylus and nib are installed)

Fixes #1452