### PR TITLE
Fix memory leak when ColumnSet is used with Editor

### DIFF
--- a/ColumnSet.js
+++ b/ColumnSet.js
@@ -185,6 +185,12 @@ define([
 		//		columns from each other. This mainly serves the purpose of allowing for
 		//		column locking.
 
+		constructor: function () {
+			if ('_editorInstances' in this) {
+				throw new Error('When used with Editor ColumnSet must be mixed in before Editor.');
+			}
+		},
+
 		postCreate: function () {
 			var self = this;
 			this.inherited(arguments);

--- a/Editor.js
+++ b/Editor.js
@@ -168,9 +168,13 @@ define([
 			this._editorsPendingStartup = [];
 		},
 
+		configStructure: function () {
+			this._alwaysOnWidgetColumns = [];
+			this.inherited(arguments);
+		},
+
 		_configColumns: function () {
 			var columnArray = this.inherited(arguments);
-			this._alwaysOnWidgetColumns = [];
 			for (var i = 0, l = columnArray.length; i < l; i++) {
 				if (columnArray[i].editor) {
 					this._configureEditorColumn(columnArray[i]);

--- a/doc/components/mixins/ColumnSet.md
+++ b/doc/components/mixins/ColumnSet.md
@@ -56,3 +56,7 @@ The ColumnSet mixin supports the following additional instance methods.
 Method | Description
 ------ | -----------
 `styleColumnSet(columnsetId, css)` | Programmatically adds styles to a columnset, by injecting a rule into a stylesheet in the document.  Returns a handle with a `remove` function, which can be called to later remove the added style rule.  Styles added via this method will be removed when the instance is destroyed if `cleanAddedRules` is set to `true`.
+
+## Mixin Order
+
+`ColumnSet` must be mixed in **before** `Editor` when both are used together.


### PR DESCRIPTION
`Editor#_configColumns` was written with the expectation that `_configColumns()` would only be invoked once when the columns are set. `ColumnSet#configStructure` calls `_configColumns` for each column set, which causes `Editor` to lose track of editor widgets when the `_alwaysOnWidgetColumns` array is destructively initialized.

This PR moves initialization of the `_alwaysOnWidgetColumns` array into `configStructure` to ensure it is initialized when appropriate and not destructively over-written. Analysis of the sequence of events when a grid is created with both `ColumnSet` and `Editor` points to this as the best point in the code to land the fix despite the fact that it only works if `ColumnSet` is mixed in before `Editor`. To enforce this mixin order the `ColumnSet` constructor will throw an error if it detects that `Editor's` constructor has already executed. This requirement is also added to the documentation for `ColumnSet`.

Fixes #1412