### PR TITLE
Editor: unpause paused handler after widget destruction

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -104,6 +104,7 @@ define([
 				if (widget) {
 					this._editorFocusoutHandle.pause();
 					widget.destroyRecursive();
+					this._editorFocusoutHandle.resume();
 				}
 			}
 


### PR DESCRIPTION
`Editor#removeRow` [pauses the focusout handler](https://github.com/SitePen/dgrid/blob/488aae2106b54b4e22df04b9c5ef30011c281c7f/Editor.js#L105) when destroying a widget, but fails to resume it. The result is that any row removal causes the focusout handler to be permanently disabled. This PR resumes the handler after the widget is destroyed.

Fixes #1456