### PR TITLE
Fix checkbox/radio shared editor on Mac

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -508,13 +508,12 @@ define([
 		//
 		// summary:
 		//		Create a focus wrapper for an editor component
-		// cmp:
-		//		editor component which can be:
-		//		1. an HTMLInputElement
-		//		2. a Dijit widget instance
-		//		3. an HTMLDivElement that wraps a #1 or #2
+		// node:
+		//		the node to wrap, either a plain HTMLInputElement or the root node of a widget (widget.domNode)
+		// tabIndex:
+		//		[optional] tabIndex value to set on the wrapper node, defaults to the node's tabIndex or -1
 		//	returns:
-		//		HTMLInputElement or Dijit widget instance
+		//		HTMLDivElement that has `node` as its only child
 		_createEditorFocusWrapper: function (node, tabIndex) {
 			if (isNaN(tabIndex)) {
 				if (isNaN(node.tabIndex)) {
@@ -704,7 +703,7 @@ define([
 
 					// Some browsers on OS X emit a blur event when a focused checkbox is clicked
 					// Revert the erroneous blur by refocusing the wrapper and exit
-					// (see notes above in _createEditor where the wrapper node is created)
+					// (see notes above on the _createEditorFocusWrapper method)
 					if (wrapperNode && event.relatedTarget === (cmp.focusNode || cmp)) {
 						wrapperNode.focus();
 						return;

--- a/test/Editor.html
+++ b/test/Editor.html
@@ -102,6 +102,13 @@
 								}
 							},
 							{
+								label: 'dijit/form/RadioButton',
+								generate: generateBool,
+								column: {
+									editorArgs: { value: "true" }
+								}
+							},
+							{
 								label: "dijit/form/ValidationTextBox",
 								generate: generateText,
 								column: { editorArgs: { required: true } }


### PR DESCRIPTION
Editor: wrap checkbox and radio button shared editors on Mac
    
In OS X form controls are not considered focusable elements. Some browsers
(Safari, Firefox) adopt this decision:
whatwg/html/issues/4356
https://bugzilla.mozilla.org/show_bug.cgi?id=1524863
https://bugs.webkit.org/show_bug.cgi?id=22261
The resulting implementation is broken - you can call `focus()` on a checkbox
and it will be focused, but clicking on a checkbox does not focus it. Further,
clicking on a focused checkbox blurs it. To overcome these challenges
checkboxes and radios are wrapped in a div that can receive focus (and blur)
in a consistent manner. Without the wrapper a valid blur is indistinguishable from an invalid blur. With the wrapper the blur event's `target` and `relatedTarget` enable reliably identifying invalid blurs and [ignoring them](https://github.com/msssk/dgrid/blob/1458-mac-checkbox/Editor.js#L701-L712).

### Notes

* This PR changes the way Dijit widget events are monitored - instead of using widget events, the DOM events are used directly. Widget events are not useful in this situation since they pass no `event` object; `event.target` and `event.relatedTarget` are crucial for this solution. In testing with `dijit/form/CheckBox` and `dijit/form/RadioButton` functionality remains the same.
  * https://github.com/SitePen/dgrid/blob/3a7416f46bdffa470e868d3578ad6678a4c86723/Editor.js#L276
    * Previously, `cmp.focus()` would either call `HTMLInputElement#focus` or a widget's `focus` method, with this PR the widget's `focusNode` is used, so `HTMLInputElement#focus` is always called
  * https://github.com/SitePen/dgrid/blob/3a7416f46bdffa470e868d3578ad6678a4c86723/Editor.js#L766
    * Previously, `on.pausable(cmp, 'blur', onblur)` would listen for a widget's `blur` event if `cmp` was a widget. With this PR a listener for `blur` is registered directly on the widget's `focusNode`.
* As of April 2020, out of testing Chrome, Firefox, and Safari on OS X, the broken behavior has only been observed in Firefox and Safari. However, at the core the problem is an issue with OS X's decision on which form controls are focusable elements, so the fix is being applied if `has('mac')` is true ([1](https://github.com/SitePen/dgrid/blob/3a7416f46bdffa470e868d3578ad6678a4c86723/Editor.js#L565), [2](https://github.com/SitePen/dgrid/blob/3a7416f46bdffa470e868d3578ad6678a4c86723/Editor.js#L610)) without further detection of which browser. The fix is unnecessary in unaffected browsers, but in testing works fine.

Fixes #1458