### PR TITLE
Selection: ignore right mouse click

### DIFF
--- a/Selection.js
+++ b/Selection.js
@@ -1,15 +1,14 @@
 define([
 	'dojo/_base/declare',
-	'dojo/dom-class',
-	'dojo/on',
-	'dojo/has',
 	'dojo/aspect',
-	'./List',
+	'dojo/dom-class',
+	'dojo/mouse',
+	'dojo/on',
+	'dojo/sniff',
 	'dojo/has!touch?./util/touch',
-	'dojo/query',
-	'dojo/_base/sniff',
+	'dojo/query', // for on.selector
 	'dojo/dom' // for has('css-user-select') in 1.8.2+
-], function (declare, domClass, on, has, aspect, List, touchUtil) {
+], function (declare, aspect, domClass, mouse, on, has, touchUtil) {
 
 	has.add('dom-comparedocumentposition', function (global, doc, element) {
 		return !!element.compareDocumentPosition;
@@ -214,6 +213,10 @@ define([
 		},
 
 		_handleSelect: function (event, target) {
+			if (mouse.isRight(event)) {
+				return;
+			}
+
 			// Don't run if selection mode doesn't have a handler (incl. "none"), target can't be selected,
 			// or if coming from a dgrid-cellfocusin from a mousedown
 			if (!this[this._selectionHandlerName] || !this.allowSelect(this.row(target)) ||


### PR DESCRIPTION
When clicking a row or cell with the secondary mouse button it is not expected
that a selection event should occur. This change updates `Selection.js` to
ignore right mouse clicks. This behavior is in line with Dojo (fixed in [1.10.5](https://github.com/dojo/dojo/commit/40012adf7d42cfff8feb34363b48ec83592a441b)).

Fixes #1354