### PR TITLE
Editor: fix editOn cell reverting to read state when widget dropdown is opened

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -697,6 +697,12 @@ define([
 			function onblur(event) {
 				var wrapperNode;
 
+				// a blur caused by clicking within an editor widget's dropDown (e.g. dijit/form/Select) should be
+				// ignored, otherwise the cell reverts to the read state when the user opens the dropdown
+				if (cmp.dropDown && cmp.dropDown.domNode.contains(event.relatedTarget || document.activeElement)) {
+					return;
+				}
+
 				if (event && event.target) {
 					wrapperNode = event.target;
 					wrapperNode = domClass.contains(wrapperNode, self.editorFocusWrapperClassName) && wrapperNode;

--- a/test/Editor_more_widgets.html
+++ b/test/Editor_more_widgets.html
@@ -13,14 +13,15 @@
 				font-weight: bold;
 				padding-bottom: 0.25em;
 			}
-			#grid .field-date, #grid .field-date2 {
+			#grid .field-date,
+			#grid .field-date2 {
 				width: 16em;
 			}
 			#grid .field-integer {
 				width: 6em;
 			}
 			#grid .field-bool {
-				width: 6em;
+				width: 7em;
 			}
 			.dgrid {
 				margin: 10px;


### PR DESCRIPTION
If a cell has `editOn: 'click'` and `dijit/form/Select` as the editor, clicking
the cell displays the Select, but clicking the Select to open the dropdown
causes a blur which reverts the cell to the read state. This change ignores
blur events from clicking within the dropdown.

Might fix #1311