### PR TITLE
Fix editor value being lost when window loses focus

### DIFF
--- a/Editor.js
+++ b/Editor.js
@@ -697,6 +697,12 @@ define([
 			function onblur(event) {
 				var wrapperNode;
 
+				// a blur caused by clicking within an editor widget's dropDown (e.g. dijit/form/Select) should be
+				// ignored, otherwise the cell reverts to the read state when the user opens the dropdown
+				if (cmp.dropDown && cmp.dropDown.domNode.contains(event.relatedTarget || document.activeElement)) {
+					return;
+				}
+
 				if (event && event.target) {
 					wrapperNode = event.target;
 					wrapperNode = domClass.contains(wrapperNode, self.editorFocusWrapperClassName) && wrapperNode;

--- a/test/Editor_more_widgets.html
+++ b/test/Editor_more_widgets.html
@@ -13,14 +13,15 @@
 				font-weight: bold;
 				padding-bottom: 0.25em;
 			}
-			#grid .field-date, #grid .field-date2 {
+			#grid .field-date,
+			#grid .field-date2 {
 				width: 16em;
 			}
 			#grid .field-integer {
 				width: 6em;
 			}
 			#grid .field-bool {
-				width: 6em;
+				width: 7em;
 			}
 			.dgrid {
 				margin: 10px;


### PR DESCRIPTION
Further testing related to #1311 revealed another problematic scenario which can be observed in `test/Editor_more_widgets.html`:
1. Click a cell in the "Select Store" column
2. Change the value in the select
3. Activate a different application (causing the browser to lose focus)

Result: the edited cell reverts to its previous value and `Grid.js` throws an error in `Grid#cell()`

This change fixes the focus event handling for this scenario.