### PR TITLE
Add Node.js REST server and client-side REST mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
 	},
 	"main": "./OnDemandGrid",
 	"icon": "http://packages.dojofoundation.org/images/dgrid.png",
+	"scripts": {
+		"test-server": "node ./test/data/rest-node.js"
+	},
 	"dojoBuild": "package.js"
 }

--- a/test/Rest.html
+++ b/test/Rest.html
@@ -9,6 +9,10 @@
 			@import "../css/dgrid.css";
 			@import "../css/skins/claro.css";
 
+			body {
+				padding-left: 2rem;
+			}
+
 			h2 {
 				margin: 12px;
 			}
@@ -22,165 +26,165 @@
 				margin: 10px;
 			}
 		</style>
-		<script>
-			var dojoConfig = {
-				async: true,
-				requestProvider: 'dojo/request/registry'
-			};
-		</script>
-		<script src="../../dojo/dojo.js"></script>
-		<script>
-			require([
-				"dojo/_base/declare",
-				"dojo/_base/lang",
-				"dojo/Deferred",
-				"dojo/query",
-				"dojo/request/registry",
-				"dgrid/List",
-				"dgrid/OnDemandGrid",
-				"dgrid/Selection",
-				"dgrid/Editor",
-				"dgrid/Keyboard",
-				"dgrid/Tree",
-				"dgrid/test/data/restMock",
-				"dstore/Rest",
-				"dstore/Trackable",
-				"dstore/Cache",
-				"dstore/Tree",
-				"dojo/domReady!"
-			], function (declare, lang, Deferred, query, requestRegistry, List, Grid, Selection,
-				Editor, Keyboard, Tree, restMock, Rest, Trackable, Cache, TreeStore) {
-
-				//var TARGET_URL = "./data/rest.php"; // PHP server
-				var TARGET_URL = window.location.origin + ":8040/data/rest"; // Node.js server
-				// comment out the line below to disable client-side request mocking and send requests to the server
-				requestRegistry.register(/data\/rest/, restMock);
-
-				var CustomGrid = declare([Grid, Selection, Keyboard, Editor, Tree], {
-					insertRow: function () {
-						refreshed = true;
-						return this.inherited(arguments);
-					},
-
-					removeRow: function () {
-						refreshed = true;
-						return this.inherited(arguments);
-					},
-
-					logPreload: function () {
-						var line = '';
-						for (var i = 0; i < 160; i++) {
-							line += '\u2500';
-						}
-						console.log(line);
-						var preload = this.preload;
-						if (preload) {
-							while (preload.previous) {
-								preload = preload.previous;
-							}
-							var preloads = [];
-							var preloadNodes = [];
-							var height = 0;
-							var totalPossibleRows = 0;
-							while (preload) {
-								preloads.push(preload);
-								var node = preload.node;
-								height += node.offsetHeight;
-								totalPossibleRows += preload.count;
-								preloadNodes.push({
-									preloadId: node.getAttribute('data-preloadid'),
-									rowIndex: node.rowIndex,
-									height: node.style.height,
-									offsetTop: node.offsetTop,
-									offsetHeight: node.offsetHeight
-								});
-								preload = preload.next;
-							}
-							console.table(preloads);
-							console.table(preloadNodes);
-							var realRowCount = query('.dgrid-row', grid.contentNode).length;
-							height += 24 * realRowCount;
-							totalPossibleRows += realRowCount;
-							console.log('Height calculated from preloads = ', height);
-
-
-							console.log('Actual grid content height = ', gridContentHeight());
-							console.log('Total possible rows = ', totalPossibleRows);
-							console.log('Current row count = ', realRowCount);
-						}
-					}
-				});
-
-				function createStore(config) {
-					var store = new declare([Rest, Trackable, Cache, TreeStore])(lang.mixin({
-						target: TARGET_URL,
-						put: function (object) {
-							var dfd = new Deferred();
-							dfd.resolve(object);
-							return dfd.promise;
-						}
-					}, config));
-
-					store.getRootCollection = function () {
-						return this.root.filter({ parent: undefined });
-					};
-
-					return store;
-				}
-
-				function getColumns() {
-					return [
-						{ label: 'Name', field: 'name', sortable: false, renderExpando: true },
-						{ label: 'Id', field: 'id' },
-						{ label: 'Comment', field: 'comment', sortable: false, editor: "text" },
-						{ label: 'Boolean', field: 'boo', sortable: false, autoSave: true, editor: "checkbox" }
-					];
-				}
-
-				window.grid = new CustomGrid({
-					pagingMethod: 'throttleDelayed',
-					collection: createStore().getRootCollection(),
-					sort: "id",
-					getBeforePut: false,
-					columns: getColumns()
-				}, "grid");
-
-				var refreshed = false;
-				var prevContentHeight = 0;
-				setInterval(function () {
-					var contentHeight = gridContentHeight();
-					if (refreshed || prevContentHeight != contentHeight) {
-						prevContentHeight = contentHeight;
-						refreshed = false;
-						grid.logPreload();
-					}
-				}, 1500);
-
-				function gridContentHeight() {
-					var contentHeight = 0;
-					var childNodes = grid.contentNode.childNodes;
-					var len = childNodes.length;
-					for (var i = 0; i < len; i++) {
-						contentHeight += childNodes[i].offsetHeight;
-					}
-					return contentHeight;
-				}
-
-				new CustomGrid({
-					collection: createStore({ useRangeHeaders: true }).getRootCollection(),
-					sort: "id",
-					getBeforePut: false,
-					columns: getColumns()
-				}, "gridRangeHeaders");
-			});
-
-		</script>
 	</head>
+
 	<body class="claro">
+		<div id="selectServerForm"></div>
+
 		<h2>A basic grid with Rest store</h2>
 		<div id="grid"></div>
 
 		<h2>A basic grid with Rest store using range headers</h2>
 		<div id="gridRangeHeaders"></div>
+
+		<script>
+			var dojoConfig = {
+				async: true,
+				requestProvider: "dojo/request/registry"
+			};
+		</script>
+		<script src="../../dojo/dojo.js"></script>
+		<script>
+			require([
+				'dojo/_base/lang',
+				'dojo/Deferred',
+				'dojo/query',
+				'dgrid/List',
+				'dgrid/OnDemandGrid',
+				'dgrid/Selection',
+				'dgrid/Editor',
+				'dgrid/Keyboard',
+				'dgrid/Tree',
+				'dgrid/test/widgets/SelectServer',
+				'dstore/Rest',
+				'dstore/Trackable',
+				'dstore/Cache',
+				'dstore/Tree'
+			], function (lang, Deferred, query, List, Grid, Selection, Editor, Keyboard, Tree,
+				SelectServer, Rest, Trackable, Cache, TreeStore) {
+
+				var selectServer = new SelectServer({}, document.getElementById('selectServerForm'));
+
+				selectServer.startup();
+				selectServer.startupPromise.then(function () {
+					var CustomGrid = Grid.createSubclass([ Selection, Keyboard, Editor, Tree ], {
+						insertRow: function () {
+							refreshed = true;
+							return this.inherited(arguments);
+						},
+
+						removeRow: function () {
+							refreshed = true;
+							return this.inherited(arguments);
+						},
+
+						logPreload: function () {
+							var line = '';
+							for (var i = 0; i < 160; i++) {
+								line += '\u2500';
+							}
+							console.log(line);
+							var preload = this.preload;
+							if (preload) {
+								while (preload.previous) {
+									preload = preload.previous;
+								}
+								var preloads = [];
+								var preloadNodes = [];
+								var height = 0;
+								var totalPossibleRows = 0;
+								while (preload) {
+									preloads.push(preload);
+									var node = preload.node;
+									height += node.offsetHeight;
+									totalPossibleRows += preload.count;
+									preloadNodes.push({
+										preloadId: node.getAttribute('data-preloadid'),
+										rowIndex: node.rowIndex,
+										height: node.style.height,
+										offsetTop: node.offsetTop,
+										offsetHeight: node.offsetHeight
+									});
+									preload = preload.next;
+								}
+								console.table(preloads);
+								console.table(preloadNodes);
+								var realRowCount = query('.dgrid-row', grid.contentNode).length;
+								height += 24 * realRowCount;
+								totalPossibleRows += realRowCount;
+								console.log('Height calculated from preloads = ', height);
+
+
+								console.log('Actual grid content height = ', gridContentHeight());
+								console.log('Total possible rows = ', totalPossibleRows);
+								console.log('Current row count = ', realRowCount);
+							}
+						}
+					});
+
+					function createStore(config) {
+						var store = new (Rest.createSubclass([ Trackable, Cache, TreeStore ]))(lang.mixin({
+							target: selectServer.get('targetUrl'),
+							put: function (object) {
+								var dfd = new Deferred();
+								dfd.resolve(object);
+								return dfd.promise;
+							}
+						}, config));
+
+						store.getRootCollection = function () {
+							return this.root.filter({ parent: undefined });
+						};
+
+						return store;
+					}
+
+					function getColumns() {
+						return [
+							{ label: 'Name', field: 'name', sortable: false, renderExpando: true },
+							{ label: 'Id', field: 'id' },
+							{ label: 'Comment', field: 'comment', sortable: false, editor: 'text' },
+							{ label: 'Boolean', field: 'boo', sortable: false, autoSave: true, editor: 'checkbox' }
+						];
+					}
+
+					window.grid = new CustomGrid({
+						pagingMethod: 'throttleDelayed',
+						collection: createStore().getRootCollection(),
+						sort: 'id',
+						getBeforePut: false,
+						columns: getColumns()
+					}, 'grid');
+
+					var refreshed = false;
+					var prevContentHeight = 0;
+					setInterval(function () {
+						var contentHeight = gridContentHeight();
+						if (refreshed || prevContentHeight != contentHeight) {
+							prevContentHeight = contentHeight;
+							refreshed = false;
+							grid.logPreload();
+						}
+					}, 1500);
+
+					function gridContentHeight() {
+						var contentHeight = 0;
+						var childNodes = grid.contentNode.childNodes;
+						var len = childNodes.length;
+						for (var i = 0; i < len; i++) {
+							contentHeight += childNodes[i].offsetHeight;
+						}
+						return contentHeight;
+					}
+
+					new CustomGrid({
+						collection: createStore({ useRangeHeaders: true }).getRootCollection(),
+						sort: 'id',
+						getBeforePut: false,
+						columns: getColumns()
+					}, 'gridRangeHeaders');
+				});
+			});
+		</script>
 	</body>
 </html>

--- a/test/Rest.html
+++ b/test/Rest.html
@@ -22,25 +22,39 @@
 				margin: 10px;
 			}
 		</style>
-		<script src="../../dojo/dojo.js"
-				data-dojo-config="async: true"></script>
+		<script>
+			var dojoConfig = {
+				async: true,
+				requestProvider: 'dojo/request/registry'
+			};
+		</script>
+		<script src="../../dojo/dojo.js"></script>
 		<script>
 			require([
+				"dojo/_base/declare",
 				"dojo/_base/lang",
+				"dojo/Deferred",
+				"dojo/query",
+				"dojo/request/registry",
 				"dgrid/List",
 				"dgrid/OnDemandGrid",
 				"dgrid/Selection",
 				"dgrid/Editor",
 				"dgrid/Keyboard",
 				"dgrid/Tree",
-				"dojo/_base/declare",
-				"dojo/query",
+				"dgrid/test/data/restMock",
 				"dstore/Rest",
 				"dstore/Trackable",
 				"dstore/Cache",
 				"dstore/Tree",
 				"dojo/domReady!"
-			], function (lang, List, Grid, Selection, Editor, Keyboard, Tree, declare, query, Rest, Trackable, Cache, TreeStore) {
+			], function (declare, lang, Deferred, query, requestRegistry, List, Grid, Selection,
+				Editor, Keyboard, Tree, restMock, Rest, Trackable, Cache, TreeStore) {
+
+				//var TARGET_URL = "./data/rest.php"; // PHP server
+				var TARGET_URL = window.location.origin + ":8040/data/rest"; // Node.js server
+				// comment out the line below to disable client-side request mocking and send requests to the server
+				requestRegistry.register(/data\/rest/, restMock);
 
 				var CustomGrid = declare([Grid, Selection, Keyboard, Editor, Tree], {
 					insertRow: function () {
@@ -99,9 +113,11 @@
 
 				function createStore(config) {
 					var store = new declare([Rest, Trackable, Cache, TreeStore])(lang.mixin({
-						target: "./data/rest.php",
+						target: TARGET_URL,
 						put: function (object) {
-							return object;
+							var dfd = new Deferred();
+							dfd.resolve(object);
+							return dfd.promise;
 						}
 					}, config));
 

--- a/test/Rest.html
+++ b/test/Rest.html
@@ -107,8 +107,8 @@
 									});
 									preload = preload.next;
 								}
-								console.table(preloads);
-								console.table(preloadNodes);
+								console.table && console.table(preloads);
+								console.table && console.table(preloadNodes);
 								var realRowCount = query('.dgrid-row', grid.contentNode).length;
 								height += 24 * realRowCount;
 								totalPossibleRows += realRowCount;

--- a/test/Rest.html
+++ b/test/Rest.html
@@ -40,7 +40,7 @@
 		<script>
 			var dojoConfig = {
 				async: true,
-				requestProvider: "dojo/request/registry"
+				requestProvider: 'dojo/request/registry'
 			};
 		</script>
 		<script src="../../dojo/dojo.js"></script>

--- a/test/data/rest-node.js
+++ b/test/data/rest-node.js
@@ -51,7 +51,7 @@ var server = http.createServer(function (request, response) {
 		});
 	}
 
-	response.setHeader('Access-Control-Allow-Headers', '*');
+	response.setHeader('Access-Control-Allow-Headers', '*, Range, X-Range, X-Requested-With');
 	response.setHeader('Access-Control-Allow-Origin', '*');
 	response.setHeader('Access-Control-Expose-Headers', 'Content-Range');
 	response.setHeader('Content-Type', 'application/json');

--- a/test/data/rest-node.js
+++ b/test/data/rest-node.js
@@ -1,0 +1,89 @@
+/*
+A simple test server that returns dynamic data.
+Sort: not supported
+Paging: supports both "limit(count,start)" in the querystring and Range/X-Range header: items=start-end
+Hierarchical data: supports the "parent" parameter in the querystring
+See: https://github.com/SitePen/dstore/blob/master/docs/Stores.md#request
+
+Launch command: node rest-node.js
+Stop server with Ctrl+C
+*/
+var http = require('http');
+var process = require('process');
+var url = require('url');
+var restHelpers = require('./restHelpers');
+
+var PORT_NUMBER = 8040;
+var RESPONSE_DELAY_MIN = 20;
+var RESPONSE_DELAY_MAX = 100;
+var TOTAL_ITEM_COUNT = 500;
+
+var server = http.createServer(function (request, response) {
+	var requestUrl = new url.URL(request.url, 'http://' + request.headers.host);
+	var searchParams = {};
+	requestUrl.searchParams.forEach(function (value, name) {
+		searchParams[name] = value;
+	});
+	var range = restHelpers.getRangeFromSearchParams(searchParams);
+	var idPrefix = 'parent' in searchParams ?
+		searchParams.parent === 'undefined' ? '' : (searchParams.parent + '-') : '';
+	var data = [];
+	var responseDelay = RESPONSE_DELAY_MAX ?
+		Math.floor(Math.random() * ((RESPONSE_DELAY_MAX - RESPONSE_DELAY_MIN) + 1)) + 50 :
+		0;
+	var i;
+
+	if (!range) {
+		range = Object.assign({
+			start: 0,
+			end: 40
+		}, restHelpers.getRangeFromHeaders(request.headers));
+	}
+
+	range.end = Math.min(range.end, TOTAL_ITEM_COUNT);
+
+	for (i = range.start; i < range.end; i++) {
+		data.push({
+			id: idPrefix + i,
+			name: (idPrefix ? ('Child ' + idPrefix) : 'Item ') + i,
+			comment: 'hello'
+		});
+	}
+
+	response.setHeader('Access-Control-Allow-Headers', '*');
+	response.setHeader('Access-Control-Allow-Origin', '*');
+	response.setHeader('Access-Control-Expose-Headers', 'Content-Range');
+	response.setHeader('Content-Type', 'application/json');
+	response.setHeader('Content-Range', 'items ' + range.start + '-' + range.end + '/' + TOTAL_ITEM_COUNT);
+	response.write(JSON.stringify(data));
+
+	if (responseDelay) {
+		setTimeout(function () {
+			response.end();
+		}, responseDelay);
+	}
+	else {
+		response.end();
+	}
+});
+
+server.listen(PORT_NUMBER);
+console.log('server listening on port ' + PORT_NUMBER + '...');
+
+if (process.platform === 'win32') {
+	var readline = require('readline');
+	var readlineInterface = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	});
+	readlineInterface.on('SIGINT', function () {
+		process.emit('SIGINT');
+	});
+}
+
+process.on('SIGINT', function () {
+	server.close(function () {
+		console.log('server stopped');
+		process.exit();
+	});
+});

--- a/test/data/rest-node.js
+++ b/test/data/rest-node.js
@@ -8,6 +8,7 @@ See: https://github.com/SitePen/dstore/blob/master/docs/Stores.md#request
 Launch command: node rest-node.js
 Stop server with Ctrl+C
 */
+
 var http = require('http');
 var process = require('process');
 var url = require('url');

--- a/test/data/rest-node.js
+++ b/test/data/rest-node.js
@@ -30,7 +30,7 @@ var server = http.createServer(function (request, response) {
 		searchParams.parent === 'undefined' ? '' : (searchParams.parent + '-') : '';
 	var data = [];
 	var responseDelay = RESPONSE_DELAY_MAX ?
-		Math.floor(Math.random() * ((RESPONSE_DELAY_MAX - RESPONSE_DELAY_MIN) + 1)) + 50 :
+		Math.floor(Math.random() * ((RESPONSE_DELAY_MAX - RESPONSE_DELAY_MIN) + 1)) + RESPONSE_DELAY_MIN :
 		0;
 	var i;
 

--- a/test/data/restHelpers.js
+++ b/test/data/restHelpers.js
@@ -1,0 +1,57 @@
+// partial UMD - only supports AMD and CommonJS, no global
+// for use with both client-side mocking (restMock.js) and Node.js server (rest-node.js)
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+	}
+	else if (typeof exports === 'object') {
+		module.exports = factory();
+	}
+}(function () {
+	var limitRegex = /^limit\((\d+),*(\d+)*\)/;
+	var rangeHeaderRegex = /(\d+)-(\d+)/;
+
+	function getRangeFromHeaders (headers) {
+		var rangeString = headers && (headers.Range || headers.range || headers['X-Range'] || headers['x-range']);
+		var match;
+		var range;
+
+		if (rangeString) {
+			match = rangeHeaderRegex.exec(rangeString);
+			if (match && match[2]) {
+				range = {
+					start: parseInt(match[1], 10),
+					end: parseInt(match[2], 10) + 1
+				};
+			}
+		}
+
+		return range;
+	}
+
+	function getRangeFromSearchParams (searchParams) {
+		var searchParam;
+		var match;
+		var range;
+
+		for (searchParam in searchParams) {
+			match = limitRegex.exec(searchParam);
+
+			if (match) {
+				range = { start: 0 };
+
+				if (match[2]) {
+					range.start = parseInt(match[2], 10);
+				}
+				range.end = range.start + parseInt(match[1], 10);
+			}
+		}
+
+		return range;
+	}
+
+	return {
+		getRangeFromHeaders: getRangeFromHeaders,
+		getRangeFromSearchParams: getRangeFromSearchParams
+	};
+}));

--- a/test/data/restHelpers.js
+++ b/test/data/restHelpers.js
@@ -8,21 +8,27 @@
 		module.exports = factory();
 	}
 }(function () {
+	var TOTAL_ITEM_COUNT = 500;
+
 	var limitRegex = /^limit\((\d+),*(\d+)*\)/;
 	var rangeHeaderRegex = /(\d+)-(\d+)/;
+
+	function getDelay (min, max) {
+		return max ?
+			Math.floor(Math.random() * ((max - min) + 1)) + min :
+			0;
+	}
 
 	function getRangeFromHeaders (headers) {
 		var rangeString = headers && (headers.Range || headers.range || headers['X-Range'] || headers['x-range']);
 		var match;
-		var range;
+		var range = {};
 
 		if (rangeString) {
 			match = rangeHeaderRegex.exec(rangeString);
 			if (match && match[2]) {
-				range = {
-					start: parseInt(match[1], 10),
-					end: parseInt(match[2], 10) + 1
-				};
+				range.start = parseInt(match[1], 10);
+				range.end = parseInt(match[2], 10) + 1;
 			}
 		}
 
@@ -50,8 +56,44 @@
 		return range;
 	}
 
+	function getResponseData (searchParams, headers) {
+		var range = getRangeFromSearchParams(searchParams);
+		var idPrefix = 'parent' in searchParams ?
+			searchParams.parent === 'undefined' ? '' : (searchParams.parent + '-') : '';
+		var data = [];
+		var i;
+
+		if (!range) {
+			range = getRangeFromHeaders(headers);
+
+			if (!('start' in range)) {
+				range.start = 0;
+			}
+			if (!('end' in range)) {
+				range.end = 40;
+			}
+		}
+
+		range.end = Math.min(range.end, TOTAL_ITEM_COUNT);
+
+		for (i = range.start; i < range.end; i++) {
+			data.push({
+				id: idPrefix + i,
+				name: (idPrefix ? ('Child ' + idPrefix) : 'Item ') + i,
+				comment: 'hello'
+			});
+		}
+
+		return {
+			items: data,
+			contentRange: 'items ' + range.start + '-' + range.end + '/' + TOTAL_ITEM_COUNT
+		};
+	}
+
 	return {
+		getDelay: getDelay,
 		getRangeFromHeaders: getRangeFromHeaders,
-		getRangeFromSearchParams: getRangeFromSearchParams
+		getRangeFromSearchParams: getRangeFromSearchParams,
+		getResponseData: getResponseData
 	};
 }));

--- a/test/data/restMock.js
+++ b/test/data/restMock.js
@@ -27,7 +27,7 @@ define([
 			searchParams.parent === 'undefined' ? '' : (searchParams.parent + '-') : '';
 		var data = [];
 		var responseDelay = RESPONSE_DELAY_MAX ?
-			Math.floor(Math.random() * ((RESPONSE_DELAY_MAX - RESPONSE_DELAY_MIN) + 1)) + 50 :
+			Math.floor(Math.random() * ((RESPONSE_DELAY_MAX - RESPONSE_DELAY_MIN) + 1)) + RESPONSE_DELAY_MIN :
 			0;
 		var i;
 

--- a/test/data/restMock.js
+++ b/test/data/restMock.js
@@ -15,44 +15,19 @@ define([
 ], function (lang, Deferred, ioQuery, JSON, restHelpers) {
 	var RESPONSE_DELAY_MIN = 20;
 	var RESPONSE_DELAY_MAX = 100;
-	var TOTAL_ITEM_COUNT = 500;
 
 	return function restMock (url, options) {
-		var responseHeaders = {
-			'content-type': 'application/json'
-		};
 		var searchParams = ioQuery.queryToObject(url.match(/[^?]*(?:\?([^#]*))?/)[1] || '');
-		var range = restHelpers.getRangeFromSearchParams(searchParams);
-		var idPrefix = 'parent' in searchParams ?
-			searchParams.parent === 'undefined' ? '' : (searchParams.parent + '-') : '';
-		var data = [];
-		var responseDelay = RESPONSE_DELAY_MAX ?
-			Math.floor(Math.random() * ((RESPONSE_DELAY_MAX - RESPONSE_DELAY_MIN) + 1)) + RESPONSE_DELAY_MIN :
-			0;
-		var i;
-
-		if (!range) {
-			range = lang.mixin({
-				start: 0,
-				end: 40
-			}, restHelpers.getRangeFromHeaders(options.headers));
-		}
-
-		range.end = Math.min(range.end, TOTAL_ITEM_COUNT);
-
-		responseHeaders['content-range'] = 'items ' + range.start + '-' + range.end + '/' + TOTAL_ITEM_COUNT;
-
-		for (i = range.start; i < range.end; i++) {
-			data.push({
-				id: idPrefix + i,
-				name: (idPrefix ? ('Child ' + idPrefix) : 'Item ') + i,
-				comment: 'hello'
-			});
-		}
-
-		var responseText = JSON.stringify(data);
+		var responseData = restHelpers.getResponseData(searchParams, options.headers);
+		var responseHeaders = {
+			'content-type': 'application/json',
+			'content-range': responseData.contentRange
+		};
+		var responseDelay = restHelpers.getDelay(RESPONSE_DELAY_MIN, RESPONSE_DELAY_MAX);
+		var responseText = JSON.stringify(responseData.items);
 		var dfd = new Deferred();
 		var responseDfd = new Deferred();
+
 		responseDfd.resolve({
 			getHeader: function (name) {
 				return responseHeaders[name.toLowerCase()];

--- a/test/data/restMock.js
+++ b/test/data/restMock.js
@@ -1,0 +1,75 @@
+/*
+Client-side request mock for testing grids with dstore/Rest
+Sort: not supported
+Paging: supports both "limit(count,start)" in the querystring and Range/X-Range header: items=start-end
+Hierarchical data: supports the "parent" parameter in the querystring
+See: https://github.com/SitePen/dstore/blob/master/docs/Stores.md#request
+*/
+define([
+	'dojo/_base/lang',
+	'dojo/Deferred',
+	'dojo/io-query',
+	'dojo/json',
+	'./restHelpers'
+], function (lang, Deferred, ioQuery, JSON, restHelpers) {
+	var RESPONSE_DELAY_MIN = 20;
+	var RESPONSE_DELAY_MAX = 100;
+	var TOTAL_ITEM_COUNT = 500;
+
+	return function restMock (url, options) {
+		var responseHeaders = {
+			'content-type': 'application/json'
+		};
+		var searchParams = ioQuery.queryToObject(url.match(/[^?]*(?:\?([^#]*))?/)[1] || '');
+		var range = restHelpers.getRangeFromSearchParams(searchParams);
+		var idPrefix = 'parent' in searchParams ?
+			searchParams.parent === 'undefined' ? '' : (searchParams.parent + '-') : '';
+		var data = [];
+		var responseDelay = RESPONSE_DELAY_MAX ?
+			Math.floor(Math.random() * ((RESPONSE_DELAY_MAX - RESPONSE_DELAY_MIN) + 1)) + 50 :
+			0;
+		var i;
+
+		if (!range) {
+			range = lang.mixin({
+				start: 0,
+				end: 40
+			}, restHelpers.getRangeFromHeaders(options.headers));
+		}
+
+		range.end = Math.min(range.end, TOTAL_ITEM_COUNT);
+
+		responseHeaders['content-range'] = 'items ' + range.start + '-' + range.end + '/' + TOTAL_ITEM_COUNT;
+
+		for (i = range.start; i < range.end; i++) {
+			data.push({
+				id: idPrefix + i,
+				name: (idPrefix ? ('Child ' + idPrefix) : 'Item ') + i,
+				comment: 'hello'
+			});
+		}
+
+		var responseText = JSON.stringify(data);
+		var dfd = new Deferred();
+		var responseDfd = new Deferred();
+		responseDfd.resolve({
+			getHeader: function (name) {
+				return responseHeaders[name.toLowerCase()];
+			},
+			data: responseText
+		});
+
+		if (responseDelay) {
+			setTimeout(function () {
+				dfd.resolve(responseText);
+			}, responseDelay);
+		}
+		else {
+			dfd.resolve(responseText);
+		}
+
+		return lang.delegate(dfd.promise, {
+			response: responseDfd
+		});
+	};
+});

--- a/test/data/restMock.js
+++ b/test/data/restMock.js
@@ -5,6 +5,7 @@ Paging: supports both "limit(count,start)" in the querystring and Range/X-Range 
 Hierarchical data: supports the "parent" parameter in the querystring
 See: https://github.com/SitePen/dstore/blob/master/docs/Stores.md#request
 */
+
 define([
 	'dojo/_base/lang',
 	'dojo/Deferred',

--- a/test/extensions/Pagination_Tree.html
+++ b/test/extensions/Pagination_Tree.html
@@ -25,15 +25,37 @@
 				white-space: nowrap;
 			}
 		</style>
-		<script src="../../../dojo/dojo.js"
-			data-dojo-config="async: true"></script>
 		<script>
-			require(["dgrid/Grid", "dgrid/extensions/Pagination", "dgrid/Selection", "dgrid/Tree",
-					"dojo/_base/lang", "dojo/_base/declare", "dojo/dom-construct", "dojo/dom-form",
-					"dstore/Rest", "dstore/Cache", "dstore/Trackable", "dstore/Tree", "dojo/domReady!"],
-				function(Grid, Pagination, Selection, Tree,
-						lang, declare, domConstruct, domForm,
-						Rest, Cache, Trackable, TreeStore){
+			var dojoConfig = {
+				async: true,
+				requestProvider: 'dojo/request/registry'
+			};
+		</script>
+		<script src="../../../dojo/dojo.js"></script>
+		<script>
+			require([
+				"dojo/_base/declare",
+				"dojo/_base/lang",
+				"dojo/dom-construct",
+				"dojo/dom-form",
+				"dojo/request/registry",
+				"dgrid/Grid",
+				"dgrid/extensions/Pagination",
+				"dgrid/Selection",
+				"dgrid/Tree",
+				"dgrid/test/data/restMock",
+				"dstore/Rest",
+				"dstore/Cache",
+				"dstore/Trackable",
+				"dstore/Tree",
+				"dojo/domReady!"
+			], function(declare, lang, domConstruct, domForm, requestRegistry, Grid, Pagination, Selection,
+				Tree, restMock, Rest, Cache, Trackable, TreeStore){
+
+				//var TARGET_URL = "./data/rest.php"; // PHP server
+				var TARGET_URL = window.location.origin + ":8040/data/rest"; // Node.js server
+				// comment out the line below to disable client-side request mocking and send requests to the server
+				requestRegistry.register(/data\/rest/, restMock);
 
 					var CustomGrid = declare([Grid, Selection, Pagination, Tree]);
 					var testStore;

--- a/test/extensions/Pagination_Tree.html
+++ b/test/extensions/Pagination_Tree.html
@@ -52,7 +52,7 @@
 			], function(declare, lang, domConstruct, domForm, requestRegistry, Grid, Pagination, Selection,
 				Tree, restMock, Rest, Cache, Trackable, TreeStore){
 
-				//var TARGET_URL = "./data/rest.php"; // PHP server
+				//var TARGET_URL = "../data/rest.php"; // PHP server
 				var TARGET_URL = window.location.origin + ":8040/data/rest"; // Node.js server
 				// comment out the line below to disable client-side request mocking and send requests to the server
 				requestRegistry.register(/data\/rest/, restMock);
@@ -62,7 +62,7 @@
 
 					function createStore(config){
 						testStore = new declare([ Rest, Cache, Trackable, TreeStore ])(lang.mixin({
-							target:"../data/rest.php"
+							target: TARGET_URL
 						}, config));
 					}
 					createStore();

--- a/test/extensions/Pagination_Tree.html
+++ b/test/extensions/Pagination_Tree.html
@@ -8,6 +8,11 @@
 			@import "../../../dojo/resources/dojo.css";
 			@import "../../css/dgrid.css";
 			@import "../../css/skins/claro.css";
+
+			body {
+				padding-left: 2rem;
+			}
+
 			.heading {
 				font-weight: bold;
 				padding-bottom: 0.25em;
@@ -25,95 +30,11 @@
 				white-space: nowrap;
 			}
 		</style>
-		<script>
-			var dojoConfig = {
-				async: true,
-				requestProvider: 'dojo/request/registry'
-			};
-		</script>
-		<script src="../../../dojo/dojo.js"></script>
-		<script>
-			require([
-				"dojo/_base/declare",
-				"dojo/_base/lang",
-				"dojo/dom-construct",
-				"dojo/dom-form",
-				"dojo/request/registry",
-				"dgrid/Grid",
-				"dgrid/extensions/Pagination",
-				"dgrid/Selection",
-				"dgrid/Tree",
-				"dgrid/test/data/restMock",
-				"dstore/Rest",
-				"dstore/Cache",
-				"dstore/Trackable",
-				"dstore/Tree",
-				"dojo/domReady!"
-			], function(declare, lang, domConstruct, domForm, requestRegistry, Grid, Pagination, Selection,
-				Tree, restMock, Rest, Cache, Trackable, TreeStore){
-
-				//var TARGET_URL = "../data/rest.php"; // PHP server
-				var TARGET_URL = window.location.origin + ":8040/data/rest"; // Node.js server
-				// comment out the line below to disable client-side request mocking and send requests to the server
-				requestRegistry.register(/data\/rest/, restMock);
-
-					var CustomGrid = declare([Grid, Selection, Pagination, Tree]);
-					var testStore;
-
-					function createStore(config){
-						testStore = new declare([ Rest, Cache, Trackable, TreeStore ])(lang.mixin({
-							target: TARGET_URL
-						}, config));
-					}
-					createStore();
-
-					function getColumns(){
-						return [
-							{label:'Name', field:'name', sortable: false, renderExpando: true},
-							{label:'Id', field:'id', sortable: true},
-							{label:'Comment', field:'comment', sortable: false}
-						];
-					}
-
-					window.grid2 = new CustomGrid({
-						className: "dgrid-autoheight",
-						collection: testStore,
-						columns: getColumns(),
-						pagingLinks: false,
-						pagingTextBox: true,
-						firstLastArrows: true,
-						pageSizeOptions: [10, 15, 25]
-					}, "grid2");
-
-					function createGrid(args){
-						window.grid = new CustomGrid(lang.mixin({
-									collection: testStore,
-									columns: getColumns()
-								}, args),
-							"grid");
-					}
-					createGrid();
-
-					var form = document.getElementById("configForm");
-					form.onsubmit = function() {
-						var args = domForm.toObject(form);
-						args.pagingLinks = +args.pagingLinks;
-						if (!args.previousNextArrows) { args.previousNextArrows = false; }
-						if (!args.showLoadingMessage) { args.showLoadingMessage = false; }
-
-						// recreate grid using args from form
-						window.grid.destroy();
-						domConstruct.create("div", { id: "grid" }, form, "after");
-						createStore({ useRangeHeaders: args.useRangeHeaders});
-						args.useRangeHeaders = undefined;
-						createGrid(args);
-
-						return false;
-					};
-				});
-		</script>
 	</head>
+
 	<body class="claro">
+		<div id="selectServerForm"></div>
+
 		<h2>A basic grid with the Pagination extension with tree plugin</h2>
 		<h3>Configuration</h3>
 		<form id="configForm">
@@ -138,5 +59,90 @@
 		<h2>An autoheight grid with the Pagination extension,
 			with a rows-per-page drop-down</h2>
 		<div id="grid2"></div>
+
+		<script>
+			var dojoConfig = {
+				async: true,
+				requestProvider: 'dojo/request/registry'
+			};
+		</script>
+		<script src="../../../dojo/dojo.js"></script>
+		<script>
+			require([
+				'dojo/_base/lang',
+				'dojo/dom-construct',
+				'dojo/dom-form',
+				'dgrid/Grid',
+				'dgrid/extensions/Pagination',
+				'dgrid/Selection',
+				'dgrid/Tree',
+				'dgrid/test/widgets/SelectServer',
+				'dstore/Rest',
+				'dstore/Cache',
+				'dstore/Trackable',
+				'dstore/Tree'
+			], function(lang, domConstruct, domForm, Grid, Pagination, Selection,
+				Tree, SelectServer, Rest, Cache, Trackable, TreeStore){
+
+				var CustomGrid = Grid.createSubclass([ Selection, Pagination, Tree ]);
+				var selectServer = new SelectServer({}, document.getElementById('selectServerForm'));
+
+				selectServer.startup();
+				selectServer.startupPromise.then(function () {
+					var testStore;
+
+					function createStore(config){
+						testStore = new (Rest.createSubclass([ Cache, Trackable, TreeStore ]))(lang.mixin({
+							target: selectServer.get('targetUrl')
+						}, config));
+					}
+					createStore();
+
+					function getColumns(){
+						return [
+							{label:'Name', field:'name', sortable: false, renderExpando: true},
+							{label:'Id', field:'id', sortable: true},
+							{label:'Comment', field:'comment', sortable: false}
+						];
+					}
+
+					window.grid2 = new CustomGrid({
+						className: 'dgrid-autoheight',
+						collection: testStore,
+						columns: getColumns(),
+						pagingLinks: false,
+						pagingTextBox: true,
+						firstLastArrows: true,
+						pageSizeOptions: [10, 15, 25]
+					}, 'grid2');
+
+					function createGrid(args){
+						window.grid = new CustomGrid(lang.mixin({
+									collection: testStore,
+									columns: getColumns()
+								}, args),
+							'grid');
+					}
+					createGrid();
+
+					var form = document.getElementById('configForm');
+					form.onsubmit = function() {
+						var args = domForm.toObject(form);
+						args.pagingLinks = +args.pagingLinks;
+						if (!args.previousNextArrows) { args.previousNextArrows = false; }
+						if (!args.showLoadingMessage) { args.showLoadingMessage = false; }
+
+						// recreate grid using args from form
+						window.grid.destroy();
+						domConstruct.create('div', { id: 'grid' }, form, 'after');
+						createStore({ useRangeHeaders: args.useRangeHeaders});
+						args.useRangeHeaders = undefined;
+						createGrid(args);
+
+						return false;
+					};
+				});
+			});
+		</script>
 	</body>
 </html>

--- a/test/widgets/SelectServer.html
+++ b/test/widgets/SelectServer.html
@@ -1,0 +1,11 @@
+<div>
+	<h2>Choose a server for the <code>dstore/Rest</code> store:</h2>
+	<form data-dojo-attach-point="form">
+		<div><label><input name="serverType" type="radio" value="mock" checked> Client-side request mock (<code>dgrid/test/data/restMock.js</code>)</label></div>
+		<div><label><input name="serverType" type="radio" value="nodejs"> Node.js server (<code>dgrid/test/data/rest-node.js</code>)</label></div>
+		<div><label><input name="serverType" type="radio" value="php"> PHP server (<code>dgrid/test/data/rest.php</code>)</label></div>
+	</form>
+
+	<div data-dojo-attach-point="messageNode"
+		style="background: #ffd3d3; border: 2px solid red; display: none; padding: 8px"></div>
+</div>

--- a/test/widgets/SelectServer.js
+++ b/test/widgets/SelectServer.js
@@ -1,0 +1,92 @@
+define([
+	'dojo/Deferred',
+	'dojo/io-query',
+	'dojo/on',
+	'dojo/request/registry',
+	'dijit/_WidgetBase',
+	'dijit/_TemplatedMixin',
+	'../data/restMock',
+	'dojo/text!./SelectServer.html'
+], function (Deferred, ioQuery, on, requestRegistry, _WidgetBase, _TemplatedMixin, restMock, template) {
+	var NODEJS_TARGET_URL = window.location.origin + ':8040/data/rest';
+	var PHP_TARGET_URL = '../data/rest.php';
+	var TIMEOUT = 1500; // milliseconds; timeout for server up status check
+
+	return _WidgetBase.createSubclass([ _TemplatedMixin ], {
+		templateString: template,
+
+		postCreate: function () {
+			this.inherited(arguments);
+
+			this.own(on(this.form, 'change', function (event) {
+				if (event.target.value === 'mock') {
+					window.location.assign(window.location.origin + window.location.pathname);
+				}
+				else {
+					window.location.assign('?server=' + event.target.value);
+				}
+			}));
+		},
+
+		startup: function () {
+			var startupDfd = new Deferred();
+			this.startupPromise = startupDfd.promise;
+
+			this.inherited(arguments);
+
+			var self = this;
+			var searchParams = ioQuery.queryToObject(window.location.search.slice(1));
+			var value = searchParams.server;
+
+			if (value) {
+				this.form.serverType.value = value;
+			}
+			else {
+				value = 'mock';
+			}
+
+			if (value === 'mock') {
+				requestRegistry.register(/data\/rest/, restMock);
+				startupDfd.resolve();
+			}
+			else {
+				requestRegistry.get(this.get('targetUrl') + '?limit(1)', {
+					timeout: TIMEOUT
+				}).response.then(function (response) {
+					var contentType = response.getHeader('Content-Type');
+					// If PHP is not running or configured correctly `rest.php` may be served by a plain HTTP server
+					// as text or html. The PHP script is configured to set Content-Type to 'application/json'
+					if (contentType !== 'application/json') {
+						throw { response: response };
+					}
+					startupDfd.resolve(response);
+				}).otherwise(function (error) {
+					var message = 'Failed to load data from URL: ' + error.response.url + '<br>';
+					if (value === 'php') {
+						message += 'PHP must be running and configured to execute the script <code>dgrid/test/data/rest.php</code>';
+					}
+					else {
+						message += 'The Node.js server must be running: <code>npm run test-server</code>';
+					}
+					self.messageNode.innerHTML = message;
+					self.messageNode.style.display = 'inline-block';
+				});
+			}
+		},
+
+		_getTargetUrlAttr: function () {
+			var targetUrl = NODEJS_TARGET_URL;
+			var value = this.get('value');
+
+			if (value === 'php') {
+				targetUrl = PHP_TARGET_URL;
+			}
+
+			return targetUrl;
+		},
+
+		_getValueAttr: function () {
+			return this.form.serverType.value;
+		}
+	});
+});

--- a/test/widgets/SelectServer.js
+++ b/test/widgets/SelectServer.js
@@ -39,7 +39,7 @@ define([
 			var value = searchParams.server;
 
 			if (value) {
-				this.form.serverType.value = value;
+				this.set('value', value);
 			}
 			else {
 				value = 'mock';
@@ -86,7 +86,29 @@ define([
 		},
 
 		_getValueAttr: function () {
-			return this.form.serverType.value;
+			var value = '';
+			var radioInput;
+			var i;
+
+			for (i = 0; i < this.form.serverType.length; i++) {
+				radioInput = this.form.serverType[i];
+				if (radioInput.checked) {
+					value = radioInput.value;
+					break;
+				}
+			}
+
+			return value;
+		},
+
+		_setValueAttr: function (newValue) {
+			var radioInput;
+			var i;
+
+			for (i = 0; i < this.form.serverType.length; i++) {
+				radioInput = this.form.serverType[i];
+				radioInput.checked = (radioInput.value === newValue);
+			}
 		}
 	});
 });


### PR DESCRIPTION
dgrid's tests currently rely on a PHP script (`rest.php`) for testing with `dstore/Request` and `dstore/Rest`. This PR adds a Node.js server (`rest-node.js`) and client-side request mocking (`restMock.js`) with `dojo/request/registry`