### PR TITLE
_StoreMixin: clamp rows.max to a minimum of 0

### DIFF
--- a/_StoreMixin.js
+++ b/_StoreMixin.js
@@ -532,6 +532,12 @@ define([
 							rows.max--;
 						}
 
+						// max should never be less than zero; if it is the logic in the 'add, update' handler
+						// below will prevent insertion of rows (https://github.com/SitePen/dgrid/issues/1305)
+						if (rows.max < 0) {
+							rows.max = 0;
+						}
+
 						row = rows[from];
 
 						// check to make the sure the node is still there before we try to remove it


### PR DESCRIPTION
If the rows of a grid are removed from bottom to top then each row removal
will decrement `rows.max`, including the final row removal which will set
`rows.max` to -1. This breaks the logic in `_StoreMixin's` ['add, update' event
handler](https://github.com/SitePen/dgrid/blob/f9f73caaf70b457e1ac43e7efcad30e5c531822b/_StoreMixin.js#L569) preventing [insertion of new rows](https://github.com/SitePen/dgrid/blob/f9f73caaf70b457e1ac43e7efcad30e5c531822b/_StoreMixin.js#L601) when items are added to the store.

Fixes #1305