### PR TITLE
Update OnDemandList to emit dgrid-error if scrolling encounters an error

### DIFF
--- a/test/widgets/SelectServer.js
+++ b/test/widgets/SelectServer.js
@@ -8,7 +8,7 @@ define([
 	'../data/restMock',
 	'dojo/text!./SelectServer.html'
 ], function (Deferred, ioQuery, on, requestRegistry, _WidgetBase, _TemplatedMixin, restMock, template) {
-	var NODEJS_TARGET_URL = window.location.origin + ':8040/data/rest';
+	var NODEJS_TARGET_URL = 'http://' + window.location.hostname + ':8040/data/rest';
 	var PHP_TARGET_URL = '../data/rest.php';
 	var TIMEOUT = 1500; // milliseconds; timeout for server up status check
 


### PR DESCRIPTION
Fixes #1479 

OnDemandList was missing a call to `_trackError` in the code that handles scrolling data requests.