### PR TITLE
fix(a11y): add role=rowgroup to dgrid-content to fix ARIA grid ownership

### DIFF
--- a/List.js
+++ b/List.js
@@ -277,7 +277,8 @@ define([
 			this.renderHeader();
 
 			this.contentNode = this.touchNode = domConstruct.create('div', {
-				className: 'dgrid-content' + (addUiClasses ? ' ui-widget-content' : '')
+				className: 'dgrid-content' + (addUiClasses ? ' ui-widget-content' : ''),
+				role: 'rowgroup'
 			}, this.bodyNode);
 
 			if (typeof this.resizeThrottleMethod === 'string' && miscUtil[this.resizeThrottleMethod]) {


### PR DESCRIPTION
## Problem

ARIA 1.1 allows `role=grid` to own `role=row` elements either directly or through `role=rowgroup` intermediaries. dgrid's current DOM structure is:

```
div[role="grid"]
  div.dgrid-scroller          ← no role
    div.dgrid-content         ← no role  ← problem
      div[role="row"]
```

The intermediate `div.dgrid-content` with no role breaks the ARIA ownership chain. axe-core reports this as an [aria-required-children](https://dequeuniversity.com/rules/axe/4.10/aria-required-children) violation (WCAG 2.1 SC 1.3.1).

## Fix

Add `role: 'rowgroup'` to the `dgrid-content` div in `List.buildRendering()`. This satisfies the ARIA 1.1 ownership chain `grid → rowgroup → row` without any visual or behavioral change.

After the fix:
```
div[role="grid"]
  div.dgrid-scroller
    div.dgrid-content[role="rowgroup"]  ← fixed
      div[role="row"]
```

## Testing

Verified with [axe-core](https://github.com/dequelabs/axe-core) via `@axe-core/playwright` against a production dgrid 1.x application. Before this fix, `aria-required-children` fired on every grid. After this fix, no violations.